### PR TITLE
Add evaluation framework and exact-match evaluator

### DIFF
--- a/src/azathoth/evaluation/__init__.py
+++ b/src/azathoth/evaluation/__init__.py
@@ -7,11 +7,14 @@ from azathoth.evaluation.models import (
     ExpectedOutcome,
     OutcomeComparison,
 )
+from azathoth.evaluation.protocols import Evaluator, EvaluatorMetadata
 
 __all__ = [
     "EvaluationEvidence",
     "EvaluationResult",
     "EvaluationStatus",
+    "Evaluator",
+    "EvaluatorMetadata",
     "ExpectedOutcome",
     "OutcomeComparison",
 ]

--- a/src/azathoth/evaluation/__init__.py
+++ b/src/azathoth/evaluation/__init__.py
@@ -1,5 +1,6 @@
 """Evaluation domain models and interfaces."""
 
+from azathoth.evaluation.exact import ExactMatchEvaluator
 from azathoth.evaluation.models import (
     EvaluationEvidence,
     EvaluationResult,
@@ -15,6 +16,7 @@ __all__ = [
     "EvaluationStatus",
     "Evaluator",
     "EvaluatorMetadata",
+    "ExactMatchEvaluator",
     "ExpectedOutcome",
     "OutcomeComparison",
 ]

--- a/src/azathoth/evaluation/__init__.py
+++ b/src/azathoth/evaluation/__init__.py
@@ -1,5 +1,17 @@
 """Evaluation domain models and interfaces."""
 
-from azathoth.evaluation.models import ExpectedOutcome, OutcomeComparison
+from azathoth.evaluation.models import (
+    EvaluationEvidence,
+    EvaluationResult,
+    EvaluationStatus,
+    ExpectedOutcome,
+    OutcomeComparison,
+)
 
-__all__ = ["ExpectedOutcome", "OutcomeComparison"]
+__all__ = [
+    "EvaluationEvidence",
+    "EvaluationResult",
+    "EvaluationStatus",
+    "ExpectedOutcome",
+    "OutcomeComparison",
+]

--- a/src/azathoth/evaluation/exact.py
+++ b/src/azathoth/evaluation/exact.py
@@ -1,0 +1,58 @@
+"""Deterministic exact-value evaluator."""
+
+from pydantic import JsonValue
+
+from azathoth.evaluation.models import (
+    EvaluationEvidence,
+    EvaluationResult,
+    EvaluationStatus,
+    ExpectedOutcome,
+)
+from azathoth.evaluation.protocols import EvaluatorMetadata
+
+
+class ExactMatchEvaluator:
+    """Evaluate outputs using strict equality."""
+
+    def __init__(self) -> None:
+        self._metadata = EvaluatorMetadata(
+            name="exact-match",
+            description="Compare expected and actual values using equality.",
+            version="1.0.0",
+        )
+
+    @property
+    def metadata(self) -> EvaluatorMetadata:
+        return self._metadata
+
+    async def evaluate(
+        self,
+        expected: ExpectedOutcome,
+        actual: JsonValue,
+    ) -> EvaluationResult:
+        """Compare two JSON values for exact equality."""
+
+        passed = expected.value == actual
+
+        return EvaluationResult(
+            evaluator_name=self.metadata.name,
+            evaluator_version=self.metadata.version,
+            score=1.0 if passed else 0.0,
+            threshold=1.0,
+            status=(EvaluationStatus.PASSED if passed else EvaluationStatus.FAILED),
+            reason=(
+                "Actual value exactly matched expected value."
+                if passed
+                else "Actual value did not exactly match expected value."
+            ),
+            evidence=(
+                EvaluationEvidence(
+                    label="expected",
+                    value=expected.value,
+                ),
+                EvaluationEvidence(
+                    label="actual",
+                    value=actual,
+                ),
+            ),
+        )

--- a/src/azathoth/evaluation/models.py
+++ b/src/azathoth/evaluation/models.py
@@ -1,8 +1,15 @@
-"""Domain models describing expected optimization outcomes."""
+"""Domain models describing expected outcomes and completed evaluations."""
 
 from enum import StrEnum
+from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    model_validator,
+)
 
 
 class OutcomeComparison(StrEnum):
@@ -13,6 +20,13 @@ class OutcomeComparison(StrEnum):
     SCHEMA = "schema"
 
 
+class EvaluationStatus(StrEnum):
+    """The final status assigned to an evaluated result."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+
+
 class ExpectedOutcome(BaseModel):
     """A result that a candidate strategy is expected to produce."""
 
@@ -21,3 +35,46 @@ class ExpectedOutcome(BaseModel):
     description: str = Field(min_length=1)
     value: JsonValue
     comparison: OutcomeComparison
+
+
+class EvaluationEvidence(BaseModel):
+    """Structured evidence supporting an evaluator's conclusion."""
+
+    model_config = ConfigDict(frozen=True)
+
+    label: str = Field(min_length=1)
+    value: JsonValue
+
+
+class EvaluationResult(BaseModel):
+    """The recorded result of evaluating one strategy output."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID = Field(default_factory=uuid4)
+    evaluator_name: str = Field(min_length=1)
+    evaluator_version: str = Field(default="1.0.0", min_length=1)
+    score: float = Field(ge=0.0, le=1.0)
+    threshold: float = Field(default=1.0, ge=0.0, le=1.0)
+    status: EvaluationStatus
+    reason: str = Field(min_length=1)
+    evidence: tuple[EvaluationEvidence, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_status_matches_threshold(self) -> "EvaluationResult":
+        """Ensure the recorded status agrees with the normalized score."""
+
+        expected_status = (
+            EvaluationStatus.PASSED if self.score >= self.threshold else EvaluationStatus.FAILED
+        )
+
+        if self.status is not expected_status:
+            raise ValueError("Evaluation status must agree with score and threshold.")
+
+        return self
+
+    @property
+    def passed(self) -> bool:
+        """Return whether this evaluation passed."""
+
+        return self.status is EvaluationStatus.PASSED

--- a/src/azathoth/evaluation/protocols.py
+++ b/src/azathoth/evaluation/protocols.py
@@ -1,0 +1,36 @@
+"""Protocols implemented by Azathoth evaluators."""
+
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+from azathoth.evaluation.models import EvaluationResult, ExpectedOutcome
+
+
+class EvaluatorMetadata(BaseModel):
+    """Stable identifying information for an evaluator."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    version: str = Field(default="1.0.0", min_length=1)
+
+
+class Evaluator(Protocol):
+    """A component that compares an actual result with an expectation."""
+
+    @property
+    def metadata(self) -> EvaluatorMetadata:
+        """Return stable identifying metadata for this evaluator."""
+
+        ...
+
+    async def evaluate(
+        self,
+        expected: ExpectedOutcome,
+        actual: JsonValue,
+    ) -> EvaluationResult:
+        """Evaluate an actual value against an expected outcome."""
+
+        ...

--- a/tests/evaluation/test_evaluation_result.py
+++ b/tests/evaluation/test_evaluation_result.py
@@ -1,0 +1,161 @@
+"""Tests for completed evaluation result models."""
+
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from azathoth.evaluation import (
+    EvaluationEvidence,
+    EvaluationResult,
+    EvaluationStatus,
+)
+
+
+def test_evaluation_result_records_a_passing_evaluation() -> None:
+    result = EvaluationResult(
+        id=UUID("f36df416-b959-4f8a-91ca-28faef080160"),
+        evaluator_name="exact-match",
+        evaluator_version="1.0.0",
+        score=1.0,
+        threshold=1.0,
+        status=EvaluationStatus.PASSED,
+        reason="The actual value exactly matched the expected value.",
+        evidence=(
+            EvaluationEvidence(
+                label="expected",
+                value="duplicate_charge",
+            ),
+            EvaluationEvidence(
+                label="actual",
+                value="duplicate_charge",
+            ),
+        ),
+    )
+
+    assert result.score == 1.0
+    assert result.threshold == 1.0
+    assert result.status is EvaluationStatus.PASSED
+    assert result.passed is True
+    assert result.evidence[0].value == "duplicate_charge"
+
+
+def test_evaluation_result_records_a_failed_evaluation() -> None:
+    result = EvaluationResult(
+        evaluator_name="exact-match",
+        score=0.0,
+        threshold=1.0,
+        status=EvaluationStatus.FAILED,
+        reason="The actual value did not match the expected value.",
+    )
+
+    assert result.status is EvaluationStatus.FAILED
+    assert result.passed is False
+
+
+@pytest.mark.parametrize(
+    "score",
+    (
+        -0.01,
+        1.01,
+    ),
+)
+def test_evaluation_result_rejects_scores_outside_normalized_range(
+    score: float,
+) -> None:
+    with pytest.raises(ValidationError):
+        EvaluationResult(
+            evaluator_name="test-evaluator",
+            score=score,
+            status=EvaluationStatus.FAILED,
+            reason="Invalid score used by test.",
+        )
+
+
+@pytest.mark.parametrize(
+    "threshold",
+    (
+        -0.01,
+        1.01,
+    ),
+)
+def test_evaluation_result_rejects_invalid_thresholds(
+    threshold: float,
+) -> None:
+    with pytest.raises(ValidationError):
+        EvaluationResult(
+            evaluator_name="test-evaluator",
+            score=0.5,
+            threshold=threshold,
+            status=EvaluationStatus.FAILED,
+            reason="Invalid threshold used by test.",
+        )
+
+
+def test_evaluation_result_is_immutable() -> None:
+    result = EvaluationResult(
+        evaluator_name="exact-match",
+        score=1.0,
+        status=EvaluationStatus.PASSED,
+        reason="The values matched.",
+    )
+
+    with pytest.raises(ValidationError):
+        result.score = 0.0
+
+
+def test_evaluation_result_round_trips_through_json() -> None:
+    result = EvaluationResult(
+        id=UUID("3f182d53-7b25-4acf-ad70-d3723a7db469"),
+        evaluator_name="exact-match",
+        evaluator_version="1.0.0",
+        score=1.0,
+        threshold=1.0,
+        status=EvaluationStatus.PASSED,
+        reason="The actual value exactly matched the expected value.",
+        evidence=(
+            EvaluationEvidence(
+                label="expected",
+                value={
+                    "category": "duplicate_charge",
+                },
+            ),
+            EvaluationEvidence(
+                label="actual",
+                value={
+                    "category": "duplicate_charge",
+                },
+            ),
+        ),
+    )
+
+    serialized = result.model_dump_json()
+    restored = EvaluationResult.model_validate_json(serialized)
+
+    assert restored == result
+
+
+def test_evaluation_result_rejects_status_that_conflicts_with_score() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Evaluation status must agree with score and threshold",
+    ):
+        EvaluationResult(
+            evaluator_name="exact-match",
+            score=0.0,
+            threshold=1.0,
+            status=EvaluationStatus.PASSED,
+            reason="This result is internally inconsistent.",
+        )
+
+
+def test_evaluation_result_can_pass_at_a_configured_threshold() -> None:
+    result = EvaluationResult(
+        evaluator_name="semantic-similarity",
+        score=0.86,
+        threshold=0.80,
+        status=EvaluationStatus.PASSED,
+        reason="The semantic similarity exceeded the configured threshold.",
+    )
+
+    assert result.passed is True

--- a/tests/evaluation/test_exact.py
+++ b/tests/evaluation/test_exact.py
@@ -1,0 +1,117 @@
+import asyncio
+
+from azathoth.evaluation import (
+    ExactMatchEvaluator,
+    ExpectedOutcome,
+    OutcomeComparison,
+)
+
+
+def test_exact_match_passes() -> None:
+    evaluator = ExactMatchEvaluator()
+
+    expected = ExpectedOutcome(
+        description="Intent classification",
+        value="duplicate_charge",
+        comparison=OutcomeComparison.EXACT,
+    )
+
+    result = asyncio.run(
+        evaluator.evaluate(
+            expected,
+            "duplicate_charge",
+        )
+    )
+
+    assert result.passed
+    assert result.score == 1.0
+
+
+def test_exact_match_fails() -> None:
+    evaluator = ExactMatchEvaluator()
+
+    expected = ExpectedOutcome(
+        description="Intent classification",
+        value="duplicate_charge",
+        comparison=OutcomeComparison.EXACT,
+    )
+
+    result = asyncio.run(
+        evaluator.evaluate(
+            expected,
+            "refund",
+        )
+    )
+
+    assert not result.passed
+    assert result.score == 0.0
+
+
+def test_exact_match_handles_nested_json() -> None:
+    evaluator = ExactMatchEvaluator()
+
+    expected = ExpectedOutcome(
+        description="Nested response",
+        value={
+            "intent": "duplicate_charge",
+            "confidence": 0.97,
+        },
+        comparison=OutcomeComparison.EXACT,
+    )
+
+    result = asyncio.run(
+        evaluator.evaluate(
+            expected,
+            {
+                "intent": "duplicate_charge",
+                "confidence": 0.97,
+            },
+        )
+    )
+
+    assert result.passed
+
+
+def test_exact_match_detects_nested_difference() -> None:
+    evaluator = ExactMatchEvaluator()
+
+    expected = ExpectedOutcome(
+        description="Nested response",
+        value={
+            "intent": "duplicate_charge",
+            "confidence": 0.97,
+        },
+        comparison=OutcomeComparison.EXACT,
+    )
+
+    result = asyncio.run(
+        evaluator.evaluate(
+            expected,
+            {
+                "intent": "refund",
+                "confidence": 0.97,
+            },
+        )
+    )
+
+    assert not result.passed
+
+
+def test_exact_match_records_evaluator_identity() -> None:
+    evaluator = ExactMatchEvaluator()
+
+    expected = ExpectedOutcome(
+        description="Identity",
+        value="x",
+        comparison=OutcomeComparison.EXACT,
+    )
+
+    result = asyncio.run(
+        evaluator.evaluate(
+            expected,
+            "x",
+        )
+    )
+
+    assert result.evaluator_name == "exact-match"
+    assert result.evaluator_version == "1.0.0"

--- a/tests/evaluation/test_protocols.py
+++ b/tests/evaluation/test_protocols.py
@@ -1,0 +1,161 @@
+"""Tests for evaluator protocols and metadata."""
+
+import asyncio
+
+import pytest
+from pydantic import JsonValue, ValidationError
+
+from azathoth.evaluation import (
+    EvaluationEvidence,
+    EvaluationResult,
+    EvaluationStatus,
+    Evaluator,
+    EvaluatorMetadata,
+    ExpectedOutcome,
+    OutcomeComparison,
+)
+
+
+class AlwaysPassEvaluator:
+    """A test evaluator that always returns a passing result."""
+
+    def __init__(self) -> None:
+        self._metadata = EvaluatorMetadata(
+            name="always-pass",
+            description="Return a passing result for protocol testing.",
+            version="1.0.0",
+        )
+        self.received_expected: ExpectedOutcome | None = None
+        self.received_actual: JsonValue = None
+
+    @property
+    def metadata(self) -> EvaluatorMetadata:
+        return self._metadata
+
+    async def evaluate(
+        self,
+        expected: ExpectedOutcome,
+        actual: JsonValue,
+    ) -> EvaluationResult:
+        self.received_expected = expected
+        self.received_actual = actual
+
+        return EvaluationResult(
+            evaluator_name=self.metadata.name,
+            evaluator_version=self.metadata.version,
+            score=1.0,
+            threshold=1.0,
+            status=EvaluationStatus.PASSED,
+            reason="The test evaluator always passes.",
+            evidence=(
+                EvaluationEvidence(
+                    label="expected",
+                    value=expected.value,
+                ),
+                EvaluationEvidence(
+                    label="actual",
+                    value=actual,
+                ),
+            ),
+        )
+
+
+async def evaluate_output(
+    evaluator: Evaluator,
+    expected: ExpectedOutcome,
+    actual: JsonValue,
+) -> EvaluationResult:
+    """Evaluate an output without depending on a concrete evaluator type."""
+
+    return await evaluator.evaluate(expected, actual)
+
+
+def test_evaluator_metadata_records_identity() -> None:
+    metadata = EvaluatorMetadata(
+        name="exact-match",
+        description="Compare expected and actual values for equality.",
+        version="1.0.0",
+    )
+
+    assert metadata.name == "exact-match"
+    assert metadata.version == "1.0.0"
+
+
+def test_evaluator_metadata_is_immutable() -> None:
+    metadata = EvaluatorMetadata(
+        name="exact-match",
+        description="Compare expected and actual values for equality.",
+    )
+
+    with pytest.raises(ValidationError):
+        metadata.version = "2.0.0"
+
+
+def test_evaluator_metadata_rejects_empty_identity_fields() -> None:
+    with pytest.raises(ValidationError):
+        EvaluatorMetadata(
+            name="",
+            description="Compare values.",
+        )
+
+    with pytest.raises(ValidationError):
+        EvaluatorMetadata(
+            name="exact-match",
+            description="",
+        )
+
+
+def test_evaluator_can_be_invoked_through_common_protocol() -> None:
+    evaluator = AlwaysPassEvaluator()
+    expected = ExpectedOutcome(
+        description="The request has the expected category.",
+        value="duplicate_charge",
+        comparison=OutcomeComparison.EXACT,
+    )
+
+    result = asyncio.run(
+        evaluate_output(
+            evaluator=evaluator,
+            expected=expected,
+            actual="duplicate_charge",
+        )
+    )
+
+    assert result.passed is True
+    assert result.evaluator_name == "always-pass"
+    assert result.evaluator_version == "1.0.0"
+    assert result.evidence == (
+        EvaluationEvidence(
+            label="expected",
+            value="duplicate_charge",
+        ),
+        EvaluationEvidence(
+            label="actual",
+            value="duplicate_charge",
+        ),
+    )
+
+
+def test_evaluator_receives_expected_outcome_and_actual_value() -> None:
+    evaluator = AlwaysPassEvaluator()
+    expected = ExpectedOutcome(
+        description="The result contains a duplicate-charge category.",
+        value={
+            "category": "duplicate_charge",
+        },
+        comparison=OutcomeComparison.EXACT,
+    )
+    actual: JsonValue = {
+        "category": "duplicate_charge",
+    }
+
+    asyncio.run(
+        evaluate_output(
+            evaluator=evaluator,
+            expected=expected,
+            actual=actual,
+        )
+    )
+
+    assert evaluator.received_expected == expected
+    assert evaluator.received_actual == actual


### PR DESCRIPTION
## Summary

This PR introduces the first evaluation framework for Azathoth.

Strategies can already execute against immutable, event-backed context. This increment adds the ability to evaluate their outputs through a common asynchronous evaluator interface.

## Included

- Immutable `EvaluationResult` model
- Versioned evaluator metadata
- `Evaluator` protocol using structural typing
- Deterministic `ExactMatchEvaluator`
- Structured evaluation evidence
- Passing thresholds and normalized scoring
- Comprehensive unit tests

## Why

Separating execution from evaluation establishes the foundation for empirical optimization.

Future evaluators—including semantic similarity, schema validation, composite evaluators, and model-based judges—can all implement the same interface and participate in the same optimization pipeline.

## Next

The next increment will connect execution and evaluation into a complete optimization loop so strategies can be compared automatically.