### PR TITLE
Introduce model discovery and provider abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,13 @@ The MVP intentionally does **not** attempt to build autonomous agents or AGI.
 
 # High-Level Architecture
 
+# High-Level Architecture
+
 ```text
 Optimization Examples
         │
         ▼
 Candidate Strategies
-        │
-        ▼
-Prompt Rendering
-        │
-        ▼
-Language Models
         │
         ▼
 Strategy Execution
@@ -118,23 +114,35 @@ Experiment Runner
             Strategy Ranking
                     │
                     ▼
-                 Winner
-        │
-        ▼
-Strategy Scorecards
-        │
-        ▼
-Strategy Ranking
-        │
-        ▼
-Best Candidate
+              Best Candidate
+
+Strategy
+    │
+    ▼
+Context Analysis
+    │
+    ├── Prompt Rendering
+    ├── Model Discovery
+    ├── Tool Execution
+    ├── Retrieval
+    ├── Clarification Questions
+    └── Multi-step Workflow
+    │
+    ▼
+Strategy Outcome
 ```
 
 The current implementation can execute candidate strategies across a shared
 example set, aggregate their results into evidence-backed scorecards, and rank
 the candidates deterministically.
 
-The current implementation includes provider abstractions, executable prompt strategies, context-aware prompt rendering, deterministic experiments, and evidence-backed strategy ranking. Cost-aware model selection and automatic strategy generation remain future milestones.
+The framework now includes immutable optimization examples, event-backed
+context, executable strategies, context-aware prompting, provider
+abstractions, model discovery, deterministic experiment execution, and
+evidence-backed strategy ranking.
+
+Future milestones include model arbitrage, adaptive strategy generation,
+workflow synthesis, and continual learning.
 
 ---
 
@@ -259,6 +267,42 @@ Strategies may consist of combinations of:
 
 Each candidate strategy is evaluated against user-defined success criteria.
 
+---
+
+# Model Discovery
+
+Before a strategy can be evaluated, Azathoth must determine which language models are capable of executing it.
+
+Rather than embedding provider-specific logic throughout the system, Azathoth represents available models using immutable metadata.
+
+Each model records information such as:
+
+- provider
+- model identifier
+- supported capabilities
+- supported modalities
+- context window
+- output limits
+- pricing information
+
+Available models are stored within a `ModelCatalog`.
+
+Optimization components use immutable `ModelQuery` objects to discover the set of eligible candidate models for a workload.
+
+Importantly, model discovery and model selection are separate concerns.
+
+The catalog answers:
+
+> "Which models satisfy these requirements?"
+
+Optimization later answers:
+
+> "Which eligible model consistently performs best for this workload?"
+
+This separation allows provider integrations, capability discovery, and optimization policies to evolve independently.
+
+---
+
 ## Strategy execution
 
 Azathoth strategies operate against immutable, event-backed context.
@@ -319,6 +363,31 @@ Run the complete example:
 ```bash
 python examples/execute_strategy.py
 ```
+
+---
+
+# Execution Metrics
+
+Every language model invocation produces operational evidence in addition to its output.
+
+Execution metrics currently include:
+
+- provider
+- model
+- token usage
+- latency
+- estimated execution cost
+
+These measurements are propagated through strategy execution into the optimization pipeline.
+
+This allows future optimization objectives to balance multiple competing concerns, including:
+
+- quality
+- latency
+- cost
+- reliability
+
+Rather than optimizing solely for correctness, Azathoth is designed to optimize across multiple measurable dimensions.
 
 ---
 
@@ -536,6 +605,9 @@ Implemented capabilities include:
 - immutable, event-backed context;
 - asynchronous executable strategies;
 - traceable strategy execution;
+- prompt-backed and context-aware prompt strategies;
+- provider abstractions and execution metrics;
+- immutable model metadata and capability-based discovery;
 - pluggable evaluators;
 - durable optimization runs;
 - experiments across multiple strategies and examples;
@@ -553,7 +625,7 @@ The next milestones include:
 - richer evaluation methods;
 - workflow optimization across multiple execution steps.
 
-The current architecture intentionally separates execution, evaluation, experimentation, and optimization so these capabilities can be added incrementally.
+The current architecture intentionally separates execution, evaluation, experimentation, provider discovery, and optimization so these capabilities can be added incrementally.
 
 ---
 

--- a/docs/adrs/0009-model-catalog.md
+++ b/docs/adrs/0009-model-catalog.md
@@ -1,0 +1,105 @@
+# ADR 0009: Introduce an Immutable Model Catalog
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+
+## Context
+
+Azathoth's purpose is to empirically optimize AI workflows rather than hard-code decisions about prompts, models, tools, or execution paths.
+
+As support for language models was introduced, the system required a provider-neutral way to represent the available models before any optimization could occur.
+
+Without a dedicated abstraction, strategies or optimization logic would need to embed provider-specific knowledge, creating tight coupling between workflow optimization and the underlying AI providers.
+
+Additionally, future optimization will need to answer questions such as:
+
+- Which models support structured output?
+- Which models have sufficient context windows?
+- Which models support tool use?
+- Which models meet a particular pricing constraint?
+- Which models are even eligible for a particular workflow?
+
+These are discovery questions, not optimization questions.
+
+The architecture therefore requires an explicit separation between:
+
+- discovering candidate models
+- executing those models
+- evaluating their performance
+- selecting the optimal strategy
+
+## Decision
+
+Azathoth represents available language models using immutable metadata stored within a `ModelCatalog`.
+
+Each model is represented by a `ModelMetadata` object describing characteristics such as:
+
+- provider
+- model identifier
+- supported capabilities
+- supported modalities
+- context window
+- output limits
+- pricing information
+
+The `ModelCatalog` provides a reproducible inventory of configured models and supports deterministic lookup and discovery.
+
+Model discovery requirements are represented independently using immutable `ModelQuery` objects.
+
+A `ModelQuery` describes the capabilities and constraints required for a workload and is evaluated against catalog entries to determine the eligible candidate models.
+
+The catalog is intentionally limited to discovery and does not perform routing, ranking, or optimization.
+
+## Consequences
+
+### Positive
+
+- Provider-specific knowledge remains isolated from optimization logic.
+- Model discovery becomes deterministic and reproducible.
+- Capability filtering is implemented independently of optimization policy.
+- Experiments can operate over well-defined candidate model sets.
+- The architecture naturally supports future model arbitrage.
+- Model metadata can evolve independently of execution metrics.
+- The catalog can later be populated from configuration files, provider APIs, or external registries without changing optimization components.
+
+### Negative
+
+- Additional domain models are required before execution can occur.
+- Discovery introduces another architectural layer that must be maintained.
+- Provider integrations must translate provider-specific information into `ModelMetadata`.
+
+## Alternatives Considered
+
+### Strategies reference provider implementations directly
+
+This would tightly couple optimization logic to provider-specific implementations and make adding or replacing providers increasingly difficult.
+
+Rejected.
+
+### Perform capability filtering inside optimization
+
+This mixes model discovery with optimization policy and makes the optimization engine responsible for provider-specific concerns.
+
+Rejected.
+
+### Maintain provider-specific catalogs
+
+This would duplicate discovery logic across providers and prevent a uniform optimization pipeline.
+
+Rejected.
+
+## Future Direction
+
+The model catalog establishes the foundation for future model arbitrage.
+
+Future optimization components may use the catalog to:
+
+- discover eligible candidate models
+- generate experiment candidates
+- compare providers
+- optimize for quality, latency, and cost
+- automatically evaluate newly available models
+
+The catalog intentionally does not decide which model should be selected.
+
+Selection remains the responsibility of the optimization engine, allowing discovery and optimization to evolve independently.

--- a/src/azathoth/providers/__init__.py
+++ b/src/azathoth/providers/__init__.py
@@ -10,6 +10,7 @@ from azathoth.providers.models import (
     Prompt,
 )
 from azathoth.providers.protocol import LanguageModel
+from azathoth.providers.query import ModelQuery
 
 __all__ = [
     "LanguageModel",
@@ -18,6 +19,7 @@ __all__ = [
     "ModelMetadata",
     "ModelModality",
     "ModelPricing",
+    "ModelQuery",
     "ModelResponse",
     "Prompt",
 ]

--- a/src/azathoth/providers/__init__.py
+++ b/src/azathoth/providers/__init__.py
@@ -1,6 +1,10 @@
 """Language model provider abstractions."""
 
 from azathoth.providers.models import (
+    ModelCapability,
+    ModelMetadata,
+    ModelModality,
+    ModelPricing,
     ModelResponse,
     Prompt,
 )
@@ -8,6 +12,10 @@ from azathoth.providers.protocol import LanguageModel
 
 __all__ = [
     "LanguageModel",
+    "ModelCapability",
+    "ModelMetadata",
+    "ModelModality",
+    "ModelPricing",
     "ModelResponse",
     "Prompt",
 ]

--- a/src/azathoth/providers/__init__.py
+++ b/src/azathoth/providers/__init__.py
@@ -1,5 +1,6 @@
 """Language model provider abstractions."""
 
+from azathoth.providers.catalog import ModelCatalog
 from azathoth.providers.models import (
     ModelCapability,
     ModelMetadata,
@@ -13,6 +14,7 @@ from azathoth.providers.protocol import LanguageModel
 __all__ = [
     "LanguageModel",
     "ModelCapability",
+    "ModelCatalog",
     "ModelMetadata",
     "ModelModality",
     "ModelPricing",

--- a/src/azathoth/providers/catalog.py
+++ b/src/azathoth/providers/catalog.py
@@ -3,6 +3,7 @@
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from azathoth.providers.models import ModelMetadata
+from azathoth.providers.query import ModelQuery
 
 
 class ModelCatalog(BaseModel):
@@ -50,3 +51,11 @@ class ModelCatalog(BaseModel):
         """Return all models registered for one provider."""
 
         return tuple(model for model in self.models if model.provider == provider)
+
+    def find(
+        self,
+        query: ModelQuery,
+    ) -> tuple[ModelMetadata, ...]:
+        """Return models satisfying every query requirement."""
+
+        return tuple(model for model in self.models if query.matches(model))

--- a/src/azathoth/providers/catalog.py
+++ b/src/azathoth/providers/catalog.py
@@ -1,0 +1,52 @@
+"""Immutable catalog of language models available to Azathoth."""
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from azathoth.providers.models import ModelMetadata
+
+
+class ModelCatalog(BaseModel):
+    """A reproducible inventory of configured language models."""
+
+    model_config = ConfigDict(frozen=True)
+
+    models: tuple[ModelMetadata, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_unique_identifiers(self) -> "ModelCatalog":
+        """Reject duplicate provider-qualified model identifiers."""
+
+        identifiers = tuple(model.identifier for model in self.models)
+
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError("Model catalog cannot contain duplicate model identifiers.")
+
+        return self
+
+    @property
+    def identifiers(self) -> tuple[str, ...]:
+        """Return model identifiers in catalog order."""
+
+        return tuple(model.identifier for model in self.models)
+
+    @property
+    def providers(self) -> tuple[str, ...]:
+        """Return provider names in first-seen order."""
+
+        return tuple(dict.fromkeys(model.provider for model in self.models))
+
+    def get(self, identifier: str) -> ModelMetadata | None:
+        """Return a model by provider-qualified identifier."""
+
+        return next(
+            (model for model in self.models if model.identifier == identifier),
+            None,
+        )
+
+    def models_for_provider(
+        self,
+        provider: str,
+    ) -> tuple[ModelMetadata, ...]:
+        """Return all models registered for one provider."""
+
+        return tuple(model for model in self.models if model.provider == provider)

--- a/src/azathoth/providers/models.py
+++ b/src/azathoth/providers/models.py
@@ -1,6 +1,59 @@
-"""Language model request and response models."""
+"""Language model domain, request and response models."""
 
-from pydantic import BaseModel, ConfigDict
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelModality(StrEnum):
+    """An input or output modality supported by a model."""
+
+    TEXT = "text"
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+
+
+class ModelCapability(StrEnum):
+    """A discrete capability advertised by a language model."""
+
+    STRUCTURED_OUTPUT = "structured_output"
+    TOOL_USE = "tool_use"
+    VISION = "vision"
+    STREAMING = "streaming"
+
+
+class ModelPricing(BaseModel):
+    """Configured model pricing per million tokens."""
+
+    model_config = ConfigDict(frozen=True)
+
+    input_usd_per_million_tokens: float = Field(ge=0.0)
+    output_usd_per_million_tokens: float = Field(ge=0.0)
+
+
+class ModelMetadata(BaseModel):
+    """Configured identity and capabilities for an available model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    display_name: str = Field(min_length=1)
+
+    input_modalities: frozenset[ModelModality] = frozenset({ModelModality.TEXT})
+    output_modalities: frozenset[ModelModality] = frozenset({ModelModality.TEXT})
+    capabilities: frozenset[ModelCapability] = frozenset()
+
+    context_window_tokens: int = Field(gt=0)
+    maximum_output_tokens: int | None = Field(default=None, gt=0)
+    pricing: ModelPricing | None = None
+
+    @property
+    def identifier(self) -> str:
+        """Return the provider-qualified model identifier."""
+
+        return f"{self.provider}/{self.model}"
 
 
 class Prompt(BaseModel):

--- a/src/azathoth/providers/query.py
+++ b/src/azathoth/providers/query.py
@@ -1,0 +1,93 @@
+"""Queries for discovering eligible language models."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from azathoth.providers.models import (
+    ModelCapability,
+    ModelMetadata,
+    ModelModality,
+)
+
+
+class ModelQuery(BaseModel):
+    """Requirements used to discover eligible language models."""
+
+    model_config = ConfigDict(frozen=True)
+
+    providers: frozenset[str] = frozenset()
+    required_capabilities: frozenset[ModelCapability] = frozenset()
+    required_input_modalities: frozenset[ModelModality] = frozenset()
+    required_output_modalities: frozenset[ModelModality] = frozenset()
+
+    minimum_context_window_tokens: int | None = Field(
+        default=None,
+        gt=0,
+    )
+    minimum_output_tokens: int | None = Field(
+        default=None,
+        gt=0,
+    )
+
+    maximum_input_usd_per_million_tokens: float | None = Field(
+        default=None,
+        ge=0.0,
+    )
+    maximum_output_usd_per_million_tokens: float | None = Field(
+        default=None,
+        ge=0.0,
+    )
+
+    require_known_pricing: bool = False
+
+    def matches(self, model: ModelMetadata) -> bool:
+        """Return whether a model satisfies every configured requirement."""
+
+        if self.providers and model.provider not in self.providers:
+            return False
+
+        if not self.required_capabilities.issubset(model.capabilities):
+            return False
+
+        if not self.required_input_modalities.issubset(model.input_modalities):
+            return False
+
+        if not self.required_output_modalities.issubset(model.output_modalities):
+            return False
+
+        if (
+            self.minimum_context_window_tokens is not None
+            and model.context_window_tokens < self.minimum_context_window_tokens
+        ):
+            return False
+
+        if self.minimum_output_tokens is not None:
+            if model.maximum_output_tokens is None:
+                return False
+
+            if model.maximum_output_tokens < self.minimum_output_tokens:
+                return False
+
+        pricing_constraints_present = (
+            self.maximum_input_usd_per_million_tokens is not None
+            or self.maximum_output_usd_per_million_tokens is not None
+        )
+
+        if (self.require_known_pricing or pricing_constraints_present) and model.pricing is None:
+            return False
+
+        if model.pricing is not None:
+            if (
+                self.maximum_input_usd_per_million_tokens is not None
+                and model.pricing.input_usd_per_million_tokens
+                > self.maximum_input_usd_per_million_tokens
+            ):
+                return False
+
+            if (
+                self.maximum_output_usd_per_million_tokens is not None
+                and model.pricing.output_usd_per_million_tokens
+                > self.maximum_output_usd_per_million_tokens
+            ):
+                return False
+
+        return True

--- a/tests/providers/test_catalog.py
+++ b/tests/providers/test_catalog.py
@@ -1,0 +1,192 @@
+"""Tests for the immutable language model catalog."""
+
+import pytest
+from pydantic import ValidationError
+
+from azathoth.providers import (
+    ModelCapability,
+    ModelCatalog,
+    ModelMetadata,
+    ModelModality,
+    ModelPricing,
+)
+
+
+def create_model(
+    *,
+    provider: str,
+    model: str,
+    display_name: str,
+) -> ModelMetadata:
+    """Create deterministic metadata for catalog tests."""
+
+    return ModelMetadata(
+        provider=provider,
+        model=model,
+        display_name=display_name,
+        capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+            }
+        ),
+        input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+            }
+        ),
+        output_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+            }
+        ),
+        context_window_tokens=128_000,
+        maximum_output_tokens=8_192,
+        pricing=ModelPricing(
+            input_usd_per_million_tokens=1.0,
+            output_usd_per_million_tokens=4.0,
+        ),
+    )
+
+
+def create_catalog() -> ModelCatalog:
+    """Create a deterministic model catalog."""
+
+    return ModelCatalog(
+        models=(
+            create_model(
+                provider="provider-a",
+                model="small",
+                display_name="Provider A Small",
+            ),
+            create_model(
+                provider="provider-a",
+                model="large",
+                display_name="Provider A Large",
+            ),
+            create_model(
+                provider="provider-b",
+                model="reasoning",
+                display_name="Provider B Reasoning",
+            ),
+        )
+    )
+
+
+def test_catalog_preserves_model_order() -> None:
+    catalog = create_catalog()
+
+    assert catalog.identifiers == (
+        "provider-a/small",
+        "provider-a/large",
+        "provider-b/reasoning",
+    )
+
+
+def test_catalog_returns_model_by_identifier() -> None:
+    catalog = create_catalog()
+
+    model = catalog.get("provider-a/large")
+
+    assert model is not None
+    assert model.display_name == "Provider A Large"
+
+
+def test_catalog_returns_none_for_unknown_identifier() -> None:
+    catalog = create_catalog()
+
+    assert catalog.get("provider-c/missing") is None
+
+
+def test_catalog_returns_models_for_provider() -> None:
+    catalog = create_catalog()
+
+    models = catalog.models_for_provider("provider-a")
+
+    assert tuple(model.identifier for model in models) == (
+        "provider-a/small",
+        "provider-a/large",
+    )
+
+
+def test_catalog_returns_empty_tuple_for_unknown_provider() -> None:
+    catalog = create_catalog()
+
+    assert catalog.models_for_provider("unknown") == ()
+
+
+def test_catalog_lists_providers_in_first_seen_order() -> None:
+    catalog = create_catalog()
+
+    assert catalog.providers == (
+        "provider-a",
+        "provider-b",
+    )
+
+
+def test_catalog_allows_empty_inventory() -> None:
+    catalog = ModelCatalog()
+
+    assert catalog.models == ()
+    assert catalog.identifiers == ()
+    assert catalog.providers == ()
+
+
+def test_catalog_rejects_duplicate_identifiers() -> None:
+    first = create_model(
+        provider="provider-a",
+        model="small",
+        display_name="First Name",
+    )
+    duplicate = create_model(
+        provider="provider-a",
+        model="small",
+        display_name="Different Display Name",
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="duplicate model identifiers",
+    ):
+        ModelCatalog(
+            models=(
+                first,
+                duplicate,
+            )
+        )
+
+
+def test_same_model_name_is_allowed_across_providers() -> None:
+    catalog = ModelCatalog(
+        models=(
+            create_model(
+                provider="provider-a",
+                model="small",
+                display_name="Provider A Small",
+            ),
+            create_model(
+                provider="provider-b",
+                model="small",
+                display_name="Provider B Small",
+            ),
+        )
+    )
+
+    assert catalog.identifiers == (
+        "provider-a/small",
+        "provider-b/small",
+    )
+
+
+def test_catalog_is_immutable() -> None:
+    catalog = create_catalog()
+
+    with pytest.raises(ValidationError):
+        catalog.models = ()
+
+
+def test_catalog_round_trips_through_json() -> None:
+    catalog = create_catalog()
+
+    restored = ModelCatalog.model_validate_json(catalog.model_dump_json())
+
+    assert restored == catalog

--- a/tests/providers/test_catalog.py
+++ b/tests/providers/test_catalog.py
@@ -9,6 +9,7 @@ from azathoth.providers import (
     ModelMetadata,
     ModelModality,
     ModelPricing,
+    ModelQuery,
 )
 
 
@@ -190,3 +191,52 @@ def test_catalog_round_trips_through_json() -> None:
     restored = ModelCatalog.model_validate_json(catalog.model_dump_json())
 
     assert restored == catalog
+
+
+def test_catalog_finds_models_matching_query() -> None:
+    catalog = create_catalog()
+
+    models = catalog.find(
+        ModelQuery(
+            providers=frozenset({"provider-a"}),
+            required_capabilities=frozenset(
+                {
+                    ModelCapability.STRUCTURED_OUTPUT,
+                }
+            ),
+            minimum_context_window_tokens=100_000,
+        )
+    )
+
+    assert tuple(model.identifier for model in models) == (
+        "provider-a/small",
+        "provider-a/large",
+    )
+
+
+def test_catalog_find_preserves_catalog_order() -> None:
+    catalog = create_catalog()
+
+    models = catalog.find(ModelQuery())
+
+    assert tuple(model.identifier for model in models) == (
+        "provider-a/small",
+        "provider-a/large",
+        "provider-b/reasoning",
+    )
+
+
+def test_catalog_find_returns_empty_tuple_when_nothing_matches() -> None:
+    catalog = create_catalog()
+
+    models = catalog.find(
+        ModelQuery(
+            required_capabilities=frozenset(
+                {
+                    ModelCapability.TOOL_USE,
+                }
+            )
+        )
+    )
+
+    assert models == ()

--- a/tests/providers/test_model_metadata.py
+++ b/tests/providers/test_model_metadata.py
@@ -1,0 +1,111 @@
+"""Tests for configured language model metadata."""
+
+import pytest
+from pydantic import ValidationError
+
+from azathoth.providers import (
+    ModelCapability,
+    ModelMetadata,
+    ModelModality,
+    ModelPricing,
+)
+
+
+def create_metadata() -> ModelMetadata:
+    """Create deterministic metadata for provider tests."""
+
+    return ModelMetadata(
+        provider="example-provider",
+        model="reasoning-large",
+        display_name="Reasoning Large",
+        input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.IMAGE,
+            }
+        ),
+        output_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+            }
+        ),
+        capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.TOOL_USE,
+                ModelCapability.VISION,
+            }
+        ),
+        context_window_tokens=200_000,
+        maximum_output_tokens=16_000,
+        pricing=ModelPricing(
+            input_usd_per_million_tokens=2.50,
+            output_usd_per_million_tokens=10.00,
+        ),
+    )
+
+
+def test_model_metadata_records_identity_and_capabilities() -> None:
+    metadata = create_metadata()
+
+    assert metadata.identifier == "example-provider/reasoning-large"
+    assert ModelCapability.TOOL_USE in metadata.capabilities
+    assert ModelModality.IMAGE in metadata.input_modalities
+    assert metadata.context_window_tokens == 200_000
+
+
+def test_model_metadata_defaults_to_text_input_and_output() -> None:
+    metadata = ModelMetadata(
+        provider="local",
+        model="small",
+        display_name="Local Small",
+        context_window_tokens=8_192,
+    )
+
+    assert metadata.input_modalities == frozenset({ModelModality.TEXT})
+    assert metadata.output_modalities == frozenset({ModelModality.TEXT})
+    assert metadata.capabilities == frozenset()
+
+
+def test_model_metadata_allows_unknown_pricing() -> None:
+    metadata = ModelMetadata(
+        provider="internal",
+        model="experimental",
+        display_name="Experimental",
+        context_window_tokens=32_000,
+    )
+
+    assert metadata.pricing is None
+
+
+def test_model_metadata_is_immutable() -> None:
+    metadata = create_metadata()
+
+    with pytest.raises(ValidationError):
+        metadata.model = "changed"
+
+
+def test_model_metadata_rejects_invalid_context_window() -> None:
+    with pytest.raises(ValidationError):
+        ModelMetadata(
+            provider="test",
+            model="invalid",
+            display_name="Invalid",
+            context_window_tokens=0,
+        )
+
+
+def test_model_pricing_rejects_negative_values() -> None:
+    with pytest.raises(ValidationError):
+        ModelPricing(
+            input_usd_per_million_tokens=-1.0,
+            output_usd_per_million_tokens=1.0,
+        )
+
+
+def test_model_metadata_round_trips_through_json() -> None:
+    metadata = create_metadata()
+
+    restored = ModelMetadata.model_validate_json(metadata.model_dump_json())
+
+    assert restored == metadata

--- a/tests/providers/test_query.py
+++ b/tests/providers/test_query.py
@@ -1,0 +1,245 @@
+"""Tests for language model discovery queries."""
+
+import pytest
+from pydantic import ValidationError
+
+from azathoth.providers import (
+    ModelCapability,
+    ModelMetadata,
+    ModelModality,
+    ModelPricing,
+    ModelQuery,
+)
+
+
+def create_model(
+    *,
+    provider: str = "provider-a",
+    model: str = "model-a",
+    capabilities: frozenset[ModelCapability] = frozenset(),
+    input_modalities: frozenset[ModelModality] = frozenset({ModelModality.TEXT}),
+    output_modalities: frozenset[ModelModality] = frozenset({ModelModality.TEXT}),
+    context_window_tokens: int = 128_000,
+    maximum_output_tokens: int | None = 8_192,
+    pricing: ModelPricing | None = None,
+) -> ModelMetadata:
+    """Create configurable model metadata for query tests."""
+
+    return ModelMetadata(
+        provider=provider,
+        model=model,
+        display_name=f"{provider} {model}",
+        capabilities=capabilities,
+        input_modalities=input_modalities,
+        output_modalities=output_modalities,
+        context_window_tokens=context_window_tokens,
+        maximum_output_tokens=maximum_output_tokens,
+        pricing=pricing,
+    )
+
+
+def test_empty_query_matches_any_model() -> None:
+    query = ModelQuery()
+
+    assert query.matches(create_model()) is True
+
+
+def test_query_filters_by_provider() -> None:
+    query = ModelQuery(
+        providers=frozenset({"provider-b"}),
+    )
+
+    assert query.matches(create_model(provider="provider-b")) is True
+    assert query.matches(create_model(provider="provider-a")) is False
+
+
+def test_query_requires_all_capabilities() -> None:
+    query = ModelQuery(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.TOOL_USE,
+            }
+        ),
+    )
+
+    complete = create_model(
+        capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.TOOL_USE,
+                ModelCapability.STREAMING,
+            }
+        )
+    )
+    incomplete = create_model(
+        capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+            }
+        )
+    )
+
+    assert query.matches(complete) is True
+    assert query.matches(incomplete) is False
+
+
+def test_query_requires_input_modalities() -> None:
+    query = ModelQuery(
+        required_input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.IMAGE,
+            }
+        )
+    )
+
+    multimodal = create_model(
+        input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.IMAGE,
+            }
+        )
+    )
+    text_only = create_model()
+
+    assert query.matches(multimodal) is True
+    assert query.matches(text_only) is False
+
+
+def test_query_requires_output_modalities() -> None:
+    query = ModelQuery(
+        required_output_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.AUDIO,
+            }
+        )
+    )
+
+    audio_output = create_model(
+        output_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.AUDIO,
+            }
+        )
+    )
+
+    assert query.matches(audio_output) is True
+    assert query.matches(create_model()) is False
+
+
+def test_query_enforces_minimum_context_window() -> None:
+    query = ModelQuery(
+        minimum_context_window_tokens=100_000,
+    )
+
+    assert query.matches(create_model(context_window_tokens=128_000)) is True
+    assert query.matches(create_model(context_window_tokens=32_000)) is False
+
+
+def test_query_enforces_minimum_output_tokens() -> None:
+    query = ModelQuery(
+        minimum_output_tokens=8_000,
+    )
+
+    assert query.matches(create_model(maximum_output_tokens=16_000)) is True
+    assert query.matches(create_model(maximum_output_tokens=4_000)) is False
+    assert query.matches(create_model(maximum_output_tokens=None)) is False
+
+
+def test_query_can_require_known_pricing() -> None:
+    query = ModelQuery(
+        require_known_pricing=True,
+    )
+
+    priced = create_model(
+        pricing=ModelPricing(
+            input_usd_per_million_tokens=1.0,
+            output_usd_per_million_tokens=4.0,
+        )
+    )
+
+    assert query.matches(priced) is True
+    assert query.matches(create_model(pricing=None)) is False
+
+
+def test_query_enforces_input_and_output_price_limits() -> None:
+    query = ModelQuery(
+        maximum_input_usd_per_million_tokens=2.0,
+        maximum_output_usd_per_million_tokens=8.0,
+    )
+
+    affordable = create_model(
+        pricing=ModelPricing(
+            input_usd_per_million_tokens=1.5,
+            output_usd_per_million_tokens=7.0,
+        )
+    )
+    expensive_input = create_model(
+        pricing=ModelPricing(
+            input_usd_per_million_tokens=3.0,
+            output_usd_per_million_tokens=7.0,
+        )
+    )
+    expensive_output = create_model(
+        pricing=ModelPricing(
+            input_usd_per_million_tokens=1.5,
+            output_usd_per_million_tokens=10.0,
+        )
+    )
+
+    assert query.matches(affordable) is True
+    assert query.matches(expensive_input) is False
+    assert query.matches(expensive_output) is False
+
+
+def test_pricing_constraint_excludes_unknown_pricing() -> None:
+    query = ModelQuery(
+        maximum_input_usd_per_million_tokens=2.0,
+    )
+
+    assert query.matches(create_model(pricing=None)) is False
+
+
+def test_query_rejects_invalid_numeric_requirements() -> None:
+    with pytest.raises(ValidationError):
+        ModelQuery(
+            minimum_context_window_tokens=0,
+        )
+
+    with pytest.raises(ValidationError):
+        ModelQuery(
+            maximum_input_usd_per_million_tokens=-1.0,
+        )
+
+
+def test_model_query_round_trips_through_json() -> None:
+    query = ModelQuery(
+        providers=frozenset(
+            {
+                "provider-a",
+                "provider-b",
+            }
+        ),
+        required_capabilities=frozenset(
+            {
+                ModelCapability.TOOL_USE,
+            }
+        ),
+        required_input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.IMAGE,
+            }
+        ),
+        minimum_context_window_tokens=100_000,
+        maximum_input_usd_per_million_tokens=2.0,
+        require_known_pricing=True,
+    )
+
+    restored = ModelQuery.model_validate_json(query.model_dump_json())
+
+    assert restored == query


### PR DESCRIPTION
## Summary

This PR extends Azathoth's optimization framework with the abstractions required
to discover and execute language models without coupling the optimization engine
to provider-specific implementations.

### Added

- Provider-neutral language model abstraction
- Prompt-backed strategies
- Context-aware prompt rendering
- Provider execution metrics
- Immutable model metadata
- Immutable model catalog
- Capability-based model discovery

### Documentation

- Updated README to reflect the current architecture
- Added ADR 0009 describing the Model Catalog architecture

### Why

Model discovery is intentionally separated from optimization.

The catalog answers:

> Which models are eligible?

The optimizer later answers:

> Which eligible model consistently performs best?

This separation provides the architectural foundation for future model
arbitrage while keeping provider-specific concerns isolated from the
optimization pipeline.