### PR TITLE
Introduce provider-neutral model requirements and discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Most AI applications contain dozens of hidden decisions:
 
 These decisions are usually hard-coded by developers.
 
-Azathoth attempts to learn them.
+Azathoth attempts to discover them empirically.
 
 ---
 
@@ -77,8 +77,6 @@ The MVP intentionally does **not** attempt to build autonomous agents or AGI.
 
 # High-Level Architecture
 
-# High-Level Architecture
-
 ```text
 Optimization Examples
         │
@@ -117,6 +115,12 @@ Experiment Runner
               Best Candidate
 
 Strategy
+    │
+    ▼
+Model Requirements
+    │
+    ▼
+Model Discovery
     │
     ▼
 Context Analysis
@@ -215,6 +219,10 @@ Today, Azathoth can:
 - represent optimization examples as immutable domain models;
 - execute deterministic and language-model-backed strategies;
 - render prompts from immutable event-backed context;
+- abstract language model providers behind a common execution interface;
+- describe available models using immutable metadata;
+- declare provider-neutral model requirements for language-model-backed strategies;
+- discover eligible models through immutable catalogs and capability-based queries;
 - evaluate outputs using pluggable evaluators;
 - record complete optimization runs;
 - aggregate runs into evidence-backed strategy scorecards;
@@ -222,7 +230,7 @@ Today, Azathoth can:
 - record provider, model, token usage, latency, and estimated execution cost;
 - serialize every stage of the optimization pipeline.
 
-Future work will build on this foundation by generating candidate strategies automatically and optimizing across quality, latency, and cost.
+Future work will build on this foundation by generating candidate strategies automatically, selecting models empirically from eligible candidates, and optimizing across quality, latency, and cost.
 
 ---
 
@@ -300,6 +308,62 @@ Optimization later answers:
 > "Which eligible model consistently performs best for this workload?"
 
 This separation allows provider integrations, capability discovery, and optimization policies to evolve independently.
+
+---
+
+---
+
+# Model Requirements
+
+Strategies declare the capabilities they require from a language model without selecting a specific implementation.
+
+Model requirements describe the workload rather than the provider.
+
+Examples include:
+
+- required capabilities;
+- supported input and output modalities;
+- minimum context window;
+- minimum output size;
+- optional pricing constraints.
+
+```python
+requirements = ModelRequirements(
+    required_capabilities=frozenset(
+        {
+            ModelCapability.STRUCTURED_OUTPUT,
+            ModelCapability.TOOL_USE,
+        }
+    ),
+    minimum_context_window_tokens=100_000,
+)
+```
+
+Requirements intentionally do not identify a specific model.
+
+Instead, they describe the minimum characteristics needed to execute the strategy successfully.
+
+A `ModelQuery` can then be derived from those requirements to discover every eligible model within a `ModelCatalog`.
+
+```text
+Strategy
+      │
+      ▼
+Model Requirements
+      │
+      ▼
+Model Query
+      │
+      ▼
+Model Catalog
+      │
+      ▼
+Eligible Models
+```
+
+Empirical optimization later determines which eligible model performs best for a given workload.
+
+This separation allows workload definitions, provider integrations, and optimization policies to evolve independently.
 
 ---
 
@@ -399,7 +463,12 @@ A prompt strategy consists of:
 
 - a prompt template;
 - structured bindings into immutable context;
+- optional model requirements;
 - a language model abstraction.
+
+Today, prompt strategies execute against a concrete language model while optionally declaring provider-neutral model requirements.
+
+Future optimization components will use these requirements to discover eligible models automatically before empirical evaluation determines the most effective candidate.
 
 At execution time the strategy renders a prompt from the current context before executing it through a provider-neutral language model interface.
 
@@ -559,6 +628,7 @@ Possible future research areas include:
 
 - adaptive context modeling
 - automatic workflow discovery
+- adaptive model selection;
 - hierarchical planning
 - persistent episodic memory
 - continual learning
@@ -607,7 +677,7 @@ Implemented capabilities include:
 - traceable strategy execution;
 - prompt-backed and context-aware prompt strategies;
 - provider abstractions and execution metrics;
-- immutable model metadata and capability-based discovery;
+- immutable model metadata, provider-neutral requirements, and capability-based discovery;
 - pluggable evaluators;
 - durable optimization runs;
 - experiments across multiple strategies and examples;

--- a/docs/adrs/0010-model-requirements.md
+++ b/docs/adrs/0010-model-requirements.md
@@ -1,0 +1,77 @@
+# ADR 0010: Separate Model Requirements from Model Discovery
+
+- Status: Accepted
+- Date: 2026-08-02
+
+## Context
+
+Azathoth optimizes AI workflows by evaluating candidate strategies across
+multiple language models.
+
+As the system evolves, strategies should not be tightly coupled to specific
+providers or model identifiers. Instead, a strategy should describe the
+capabilities required to execute successfully, allowing the optimization
+system to determine which concrete models are eligible for evaluation.
+
+Conflating workload requirements with provider discovery would tightly couple
+optimization logic to infrastructure concerns and make future provider
+integrations, model arbitrage, and capability discovery more difficult.
+
+## Decision
+
+Language-model-backed strategies declare provider-neutral
+`ModelRequirements`.
+
+`ModelRequirements` describe the characteristics required from a language
+model, including capabilities, supported modalities, context limits, and
+optional pricing constraints.
+
+These requirements are translated into immutable `ModelQuery` objects.
+
+`ModelQuery` instances are evaluated against a `ModelCatalog`, which
+contains immutable metadata describing the language models available to
+Azathoth.
+
+The catalog is responsible only for discovering eligible models.
+
+Selection among eligible models remains the responsibility of future
+optimization policies.
+
+## Consequences
+
+### Positive
+
+- Strategies remain independent of specific providers.
+- Workload definitions become reusable across providers.
+- Provider integrations remain isolated from optimization logic.
+- Model discovery and model selection evolve independently.
+- Capability-based discovery naturally supports future model arbitrage.
+- Experiments can compare multiple eligible models without changing
+  strategy definitions.
+- Workload requirements remain immutable, serializable, and reproducible.
+
+### Negative
+
+- Introduces additional domain models (`ModelRequirements` and
+  `ModelQuery`) with intentionally similar structure.
+- Requires an explicit translation step from workload requirements to
+  catalog queries.
+
+## Alternatives Considered
+
+### Strategies directly reference model identifiers
+
+Rejected because strategy definitions become tightly coupled to provider
+implementations, making experimentation and provider replacement more
+difficult.
+
+### Combine `ModelRequirements` and `ModelQuery`
+
+Rejected because they represent different concepts.
+
+`ModelRequirements` describe what a workload needs.
+
+`ModelQuery` describes how a catalog is searched.
+
+Keeping these concepts separate preserves a clear boundary between workload
+definition and infrastructure.

--- a/src/azathoth/prompting/context_strategy.py
+++ b/src/azathoth/prompting/context_strategy.py
@@ -2,7 +2,7 @@
 
 from azathoth.context import Context
 from azathoth.prompting.models import PromptTemplate
-from azathoth.providers import LanguageModel
+from azathoth.providers import LanguageModel, ModelRequirements
 from azathoth.strategies import (
     StrategyExecutionMetrics,
     StrategyMetadata,
@@ -19,10 +19,12 @@ class ContextPromptStrategy:
         metadata: StrategyMetadata,
         template: PromptTemplate,
         language_model: LanguageModel,
+        model_requirements: ModelRequirements | None = None,
     ) -> None:
         self._metadata = metadata
         self._template = template
         self._language_model = language_model
+        self._model_requirements = model_requirements
 
     @property
     def metadata(self) -> StrategyMetadata:
@@ -35,6 +37,12 @@ class ContextPromptStrategy:
         """Return the context-aware prompt template."""
 
         return self._template
+    
+    @property
+    def model_requirements(self) -> ModelRequirements | None:
+        """Return the requirements declared for the backing model."""
+
+        return self._model_requirements
 
     async def run(self, context: Context) -> StrategyOutcome:
         """Render and execute the prompt against the supplied context."""

--- a/src/azathoth/prompting/strategy.py
+++ b/src/azathoth/prompting/strategy.py
@@ -1,7 +1,11 @@
 """Language-model-backed prompt strategies."""
 
 from azathoth.context import Context
-from azathoth.providers import LanguageModel, Prompt
+from azathoth.providers import (
+    LanguageModel,
+    ModelRequirements,
+    Prompt,
+)
 from azathoth.strategies import (
     StrategyExecutionMetrics,
     StrategyMetadata,
@@ -18,10 +22,12 @@ class PromptStrategy:
         metadata: StrategyMetadata,
         prompt: Prompt,
         language_model: LanguageModel,
+        model_requirements: ModelRequirements | None = None,
     ) -> None:
         self._metadata = metadata
         self._prompt = prompt
         self._language_model = language_model
+        self._model_requirements = model_requirements
 
     @property
     def metadata(self) -> StrategyMetadata:
@@ -34,6 +40,12 @@ class PromptStrategy:
         """Return the rendered prompt executed by this strategy."""
 
         return self._prompt
+    
+    @property
+    def model_requirements(self) -> ModelRequirements | None:
+        """Return the requirements declared for the backing model."""
+
+        return self._model_requirements
 
     async def run(self, context: Context) -> StrategyOutcome:
         """Execute the prompt and return the model response text."""

--- a/src/azathoth/providers/__init__.py
+++ b/src/azathoth/providers/__init__.py
@@ -11,6 +11,7 @@ from azathoth.providers.models import (
 )
 from azathoth.providers.protocol import LanguageModel
 from azathoth.providers.query import ModelQuery
+from azathoth.providers.requirements import ModelRequirements
 
 __all__ = [
     "LanguageModel",
@@ -20,6 +21,7 @@ __all__ = [
     "ModelModality",
     "ModelPricing",
     "ModelQuery",
+    "ModelRequirements",
     "ModelResponse",
     "Prompt",
 ]

--- a/src/azathoth/providers/query.py
+++ b/src/azathoth/providers/query.py
@@ -7,6 +7,7 @@ from azathoth.providers.models import (
     ModelMetadata,
     ModelModality,
 )
+from azathoth.providers.requirements import ModelRequirements
 
 
 class ModelQuery(BaseModel):
@@ -91,3 +92,28 @@ class ModelQuery(BaseModel):
                 return False
 
         return True
+
+    @classmethod
+    def from_requirements(
+        cls,
+        requirements: ModelRequirements,
+        *,
+        providers: frozenset[str] = frozenset(),
+    ) -> "ModelQuery":
+        """Build a catalog query from workload model requirements."""
+
+        return cls(
+            providers=providers,
+            required_capabilities=requirements.required_capabilities,
+            required_input_modalities=requirements.required_input_modalities,
+            required_output_modalities=requirements.required_output_modalities,
+            minimum_context_window_tokens=(requirements.minimum_context_window_tokens),
+            minimum_output_tokens=requirements.minimum_output_tokens,
+            maximum_input_usd_per_million_tokens=(
+                requirements.maximum_input_usd_per_million_tokens
+            ),
+            maximum_output_usd_per_million_tokens=(
+                requirements.maximum_output_usd_per_million_tokens
+            ),
+            require_known_pricing=requirements.require_known_pricing,
+        )

--- a/src/azathoth/providers/requirements.py
+++ b/src/azathoth/providers/requirements.py
@@ -1,0 +1,38 @@
+"""Provider-neutral requirements declared by model-backed workloads."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from azathoth.providers.models import (
+    ModelCapability,
+    ModelModality,
+)
+
+
+class ModelRequirements(BaseModel):
+    """Capabilities and limits required from a language model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    required_capabilities: frozenset[ModelCapability] = frozenset()
+    required_input_modalities: frozenset[ModelModality] = frozenset({ModelModality.TEXT})
+    required_output_modalities: frozenset[ModelModality] = frozenset({ModelModality.TEXT})
+
+    minimum_context_window_tokens: int | None = Field(
+        default=None,
+        gt=0,
+    )
+    minimum_output_tokens: int | None = Field(
+        default=None,
+        gt=0,
+    )
+
+    maximum_input_usd_per_million_tokens: float | None = Field(
+        default=None,
+        ge=0.0,
+    )
+    maximum_output_usd_per_million_tokens: float | None = Field(
+        default=None,
+        ge=0.0,
+    )
+
+    require_known_pricing: bool = False

--- a/tests/prompting/test_context_strategy.py
+++ b/tests/prompting/test_context_strategy.py
@@ -9,7 +9,7 @@ from azathoth.prompting import (
     PromptBinding,
     PromptTemplate,
 )
-from azathoth.providers import ModelResponse, Prompt
+from azathoth.providers import ModelCapability, ModelRequirements, ModelResponse, Prompt
 from azathoth.strategies import Strategy, StrategyMetadata
 
 
@@ -140,3 +140,48 @@ def test_context_strategy_satisfies_strategy_protocol() -> None:
     )
 
     assert output == "duplicate_charge"
+
+
+def test_context_strategy_exposes_model_requirements() -> None:
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.TOOL_USE,
+            }
+        ),
+        minimum_context_window_tokens=100_000,
+    )
+
+    strategy = ContextPromptStrategy(
+        metadata=StrategyMetadata(
+            name="Context-aware support strategy",
+            description="Classify support messages from context.",
+            version="1.0.0",
+        ),
+        template=PromptTemplate(
+            text="Classify: {message}",
+            bindings=(
+                PromptBinding(
+                    variable_name="message",
+                    event_type="customer.message.received",
+                    field_name="message",
+                ),
+            ),
+        ),
+        language_model=RecordingLanguageModel(
+            response_text="duplicate_charge",
+        ),
+        model_requirements=requirements,
+    )
+
+    assert strategy.model_requirements == requirements
+
+
+def test_context_strategy_allows_omitted_model_requirements() -> None:
+    strategy = create_strategy(
+        RecordingLanguageModel(
+            response_text="duplicate_charge",
+        )
+    )
+
+    assert strategy.model_requirements is None

--- a/tests/prompting/test_model_discovery.py
+++ b/tests/prompting/test_model_discovery.py
@@ -1,0 +1,81 @@
+"""Tests for discovering models from prompt strategy requirements."""
+
+from azathoth.prompting import PromptStrategy
+from azathoth.providers import (
+    ModelCapability,
+    ModelCatalog,
+    ModelMetadata,
+    ModelQuery,
+    ModelRequirements,
+    ModelResponse,
+    Prompt,
+)
+from azathoth.strategies import StrategyMetadata
+
+
+class StubLanguageModel:
+    """A model dependency used only to construct the prompt strategy."""
+
+    async def complete(self, prompt: Prompt) -> ModelResponse:
+        """Return a deterministic response."""
+
+        return ModelResponse(
+            text="unused",
+            provider="stub",
+            model="stub",
+            prompt_tokens=1,
+            completion_tokens=1,
+            total_tokens=2,
+            latency_ms=1,
+            estimated_cost_usd=0.0,
+        )
+
+
+def test_prompt_strategy_requirements_discover_eligible_models() -> None:
+    catalog = ModelCatalog(
+        models=(
+            ModelMetadata(
+                provider="provider-a",
+                model="structured",
+                display_name="Structured Model",
+                capabilities=frozenset(
+                    {
+                        ModelCapability.STRUCTURED_OUTPUT,
+                    }
+                ),
+                context_window_tokens=128_000,
+            ),
+            ModelMetadata(
+                provider="provider-b",
+                model="plain",
+                display_name="Plain Model",
+                context_window_tokens=128_000,
+            ),
+        )
+    )
+
+    strategy = PromptStrategy(
+        metadata=StrategyMetadata(
+            name="Structured response strategy",
+            description="Return a structured response.",
+            version="1.0.0",
+        ),
+        prompt=Prompt(
+            text="Return structured output.",
+        ),
+        language_model=StubLanguageModel(),
+        model_requirements=ModelRequirements(
+            required_capabilities=frozenset(
+                {
+                    ModelCapability.STRUCTURED_OUTPUT,
+                }
+            ),
+            minimum_context_window_tokens=100_000,
+        ),
+    )
+
+    assert strategy.model_requirements is not None
+
+    eligible = catalog.find(ModelQuery.from_requirements(strategy.model_requirements))
+
+    assert tuple(model.identifier for model in eligible) == ("provider-a/structured",)

--- a/tests/prompting/test_strategy.py
+++ b/tests/prompting/test_strategy.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from azathoth.context import Context
 from azathoth.prompting import PromptStrategy
-from azathoth.providers import ModelResponse, Prompt
+from azathoth.providers import ModelCapability, ModelRequirements, ModelResponse, Prompt
 from azathoth.strategies import Strategy, StrategyMetadata
 
 
@@ -138,3 +138,69 @@ def test_prompt_strategy_satisfies_strategy_protocol() -> None:
     )
 
     assert output == "duplicate_charge"
+
+
+def test_prompt_strategy_exposes_model_requirements() -> None:
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+            }
+        ),
+        minimum_context_window_tokens=32_000,
+    )
+
+    strategy = PromptStrategy(
+        metadata=create_metadata(),
+        prompt=Prompt(
+            text="Return structured JSON.",
+        ),
+        language_model=RecordingLanguageModel(
+            response_text='{"category":"duplicate_charge"}',
+        ),
+        model_requirements=requirements,
+    )
+
+    assert strategy.model_requirements == requirements
+
+
+def test_prompt_strategy_allows_omitted_model_requirements() -> None:
+    strategy = PromptStrategy(
+        metadata=create_metadata(),
+        prompt=Prompt(
+            text="Classify the request.",
+        ),
+        language_model=RecordingLanguageModel(
+            response_text="duplicate_charge",
+        ),
+    )
+
+    assert strategy.model_requirements is None
+
+
+def test_model_requirements_do_not_change_prompt_execution() -> None:
+    model = RecordingLanguageModel(
+        response_text="duplicate_charge",
+    )
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+            }
+        ),
+    )
+    prompt = Prompt(
+        text="Classify the request.",
+    )
+
+    strategy = PromptStrategy(
+        metadata=create_metadata(),
+        prompt=prompt,
+        language_model=model,
+        model_requirements=requirements,
+    )
+
+    outcome = asyncio.run(strategy.run(Context()))
+
+    assert model.received_prompt == prompt
+    assert outcome.output == "duplicate_charge"

--- a/tests/providers/test_catalog.py
+++ b/tests/providers/test_catalog.py
@@ -10,6 +10,7 @@ from azathoth.providers import (
     ModelModality,
     ModelPricing,
     ModelQuery,
+    ModelRequirements,
 )
 
 
@@ -240,3 +241,34 @@ def test_catalog_find_returns_empty_tuple_when_nothing_matches() -> None:
     )
 
     assert models == ()
+
+
+def test_catalog_finds_models_from_workload_requirements() -> None:
+    catalog = create_catalog()
+
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+            }
+        ),
+        minimum_context_window_tokens=100_000,
+        maximum_input_usd_per_million_tokens=2.0,
+        require_known_pricing=True,
+    )
+
+    models = catalog.find(
+        ModelQuery.from_requirements(
+            requirements,
+            providers=frozenset(
+                {
+                    "provider-a",
+                }
+            ),
+        )
+    )
+
+    assert tuple(model.identifier for model in models) == (
+        "provider-a/small",
+        "provider-a/large",
+    )

--- a/tests/providers/test_query.py
+++ b/tests/providers/test_query.py
@@ -9,6 +9,7 @@ from azathoth.providers import (
     ModelModality,
     ModelPricing,
     ModelQuery,
+    ModelRequirements,
 )
 
 
@@ -243,3 +244,95 @@ def test_model_query_round_trips_through_json() -> None:
     restored = ModelQuery.model_validate_json(query.model_dump_json())
 
     assert restored == query
+
+
+def test_query_builds_from_model_requirements() -> None:
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.TOOL_USE,
+            }
+        ),
+        required_input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.IMAGE,
+            }
+        ),
+        required_output_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+            }
+        ),
+        minimum_context_window_tokens=100_000,
+        minimum_output_tokens=8_000,
+        maximum_input_usd_per_million_tokens=2.0,
+        maximum_output_usd_per_million_tokens=8.0,
+        require_known_pricing=True,
+    )
+
+    query = ModelQuery.from_requirements(requirements)
+
+    assert query.providers == frozenset()
+    assert query.required_capabilities == requirements.required_capabilities
+    assert query.required_input_modalities == requirements.required_input_modalities
+    assert query.required_output_modalities == requirements.required_output_modalities
+    assert query.minimum_context_window_tokens == requirements.minimum_context_window_tokens
+    assert query.minimum_output_tokens == requirements.minimum_output_tokens
+    assert (
+        query.maximum_input_usd_per_million_tokens
+        == requirements.maximum_input_usd_per_million_tokens
+    )
+    assert (
+        query.maximum_output_usd_per_million_tokens
+        == requirements.maximum_output_usd_per_million_tokens
+    )
+    assert query.require_known_pricing is True
+
+
+def test_query_from_requirements_accepts_provider_restrictions() -> None:
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.TOOL_USE,
+            }
+        ),
+    )
+
+    query = ModelQuery.from_requirements(
+        requirements,
+        providers=frozenset(
+            {
+                "provider-a",
+                "provider-b",
+            }
+        ),
+    )
+
+    assert query.providers == frozenset(
+        {
+            "provider-a",
+            "provider-b",
+        }
+    )
+    assert query.required_capabilities == frozenset(
+        {
+            ModelCapability.TOOL_USE,
+        }
+    )
+
+
+def test_query_from_default_requirements_preserves_text_modalities() -> None:
+    query = ModelQuery.from_requirements(ModelRequirements())
+
+    assert query.required_input_modalities == frozenset(
+        {
+            ModelModality.TEXT,
+        }
+    )
+    assert query.required_output_modalities == frozenset(
+        {
+            ModelModality.TEXT,
+        }
+    )

--- a/tests/providers/test_requirements.py
+++ b/tests/providers/test_requirements.py
@@ -1,0 +1,118 @@
+"""Tests for language model workload requirements."""
+
+import pytest
+from pydantic import ValidationError
+
+from azathoth.providers import (
+    ModelCapability,
+    ModelModality,
+    ModelRequirements,
+)
+
+
+def test_requirements_default_to_text_input_and_output() -> None:
+    requirements = ModelRequirements()
+
+    assert requirements.required_input_modalities == frozenset({ModelModality.TEXT})
+    assert requirements.required_output_modalities == frozenset({ModelModality.TEXT})
+    assert requirements.required_capabilities == frozenset()
+
+
+def test_requirements_record_capabilities_and_limits() -> None:
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.TOOL_USE,
+            }
+        ),
+        required_input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.IMAGE,
+            }
+        ),
+        required_output_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+            }
+        ),
+        minimum_context_window_tokens=100_000,
+        minimum_output_tokens=8_000,
+        maximum_input_usd_per_million_tokens=2.0,
+        maximum_output_usd_per_million_tokens=8.0,
+        require_known_pricing=True,
+    )
+
+    assert requirements.required_capabilities == frozenset(
+        {
+            ModelCapability.STRUCTURED_OUTPUT,
+            ModelCapability.TOOL_USE,
+        }
+    )
+    assert requirements.minimum_context_window_tokens == 100_000
+    assert requirements.minimum_output_tokens == 8_000
+    assert requirements.maximum_input_usd_per_million_tokens == 2.0
+    assert requirements.maximum_output_usd_per_million_tokens == 8.0
+    assert requirements.require_known_pricing is True
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    (
+        ("minimum_context_window_tokens", 0),
+        ("minimum_output_tokens", 0),
+        ("maximum_input_usd_per_million_tokens", -0.01),
+        ("maximum_output_usd_per_million_tokens", -0.01),
+    ),
+)
+def test_requirements_reject_invalid_numeric_constraints(
+    field_name: str,
+    value: int | float,
+) -> None:
+    with pytest.raises(ValidationError):
+        ModelRequirements.model_validate(
+            {
+                field_name: value,
+            }
+        )
+
+
+def test_requirements_are_immutable() -> None:
+    requirements = ModelRequirements(
+        minimum_context_window_tokens=32_000,
+    )
+
+    with pytest.raises(ValidationError):
+        requirements.minimum_context_window_tokens = 64_000
+
+
+def test_requirements_round_trip_through_json() -> None:
+    requirements = ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.TOOL_USE,
+            }
+        ),
+        required_input_modalities=frozenset(
+            {
+                ModelModality.TEXT,
+                ModelModality.IMAGE,
+            }
+        ),
+        minimum_context_window_tokens=100_000,
+        maximum_input_usd_per_million_tokens=2.0,
+        require_known_pricing=True,
+    )
+
+    restored = ModelRequirements.model_validate_json(requirements.model_dump_json())
+
+    assert restored == requirements
+
+
+def test_requirements_do_not_require_known_pricing_by_default() -> None:
+    requirements = ModelRequirements()
+
+    assert requirements.require_known_pricing is False
+    assert requirements.maximum_input_usd_per_million_tokens is None
+    assert requirements.maximum_output_usd_per_million_tokens is None


### PR DESCRIPTION
# Summary

This PR extends Azathoth's provider architecture by separating **what a strategy requires** from **which models are available**.

Rather than coupling prompt strategies to specific providers or model identifiers, strategies can now declare provider-neutral model requirements. These requirements are translated into catalog queries that discover eligible language models without making optimization decisions.

This establishes the architectural foundation for future model arbitrage while preserving a clean separation between workload definition, provider discovery, and empirical optimization.

## Highlights

- Added immutable `ModelRequirements` for language-model-backed strategies.
- Added immutable `ModelCatalog` representing available language models.
- Added immutable `ModelQuery` for capability-based model discovery.
- Added conversion from `ModelRequirements` to `ModelQuery`.
- Added capability-based catalog filtering.
- Attached optional model requirements to prompt strategies.
- Preserved provider-neutral strategy abstractions.
- Expanded provider test coverage.
- Updated the README with model requirements and discovery architecture.
- Added ADR 0010 documenting the separation between workload requirements and model discovery.

## Architectural Impact

This PR introduces a clear separation of responsibilities:

```text
Strategy
      │
      ▼
Model Requirements
      │
      ▼
Model Query
      │
      ▼
Model Catalog
      │
      ▼
Eligible Models
      │
      ▼
Future Optimization Policies
```

Strategies now describe the characteristics required from a language model rather than selecting a concrete implementation.

The model catalog is responsible only for discovering eligible candidates.

Future optimization policies will determine which eligible model performs best for a given workload using empirical evaluation.

## Why

Separating workload requirements from provider discovery keeps strategies independent of provider implementations while enabling future capabilities such as:

- provider integrations;
- capability-based model discovery;
- empirical model arbitrage;
- automatic candidate generation;
- optimization across quality, latency, and cost.

This continues Azathoth's design philosophy of separating execution, evaluation, experimentation, provider discovery, and optimization into independently evolvable components.