### PR TITLE
Generate deterministic executable prompt strategy candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,56 @@ This separation allows provider integrations, capability discovery, and optimiza
 
 ---
 
+# Candidate Generation
+
+Prompt strategy specifications describe workloads independently of any particular language model.
+
+During optimization, Azathoth combines:
+
+- a prompt strategy specification;
+- model requirements;
+- the model catalog; and
+- the executable model registry
+
+to generate executable strategy candidates.
+
+Each generated candidate:
+
+- is bound to exactly one executable language model;
+- has a deterministic identity derived from the specification and model binding;
+- can be executed, evaluated, and ranked independently.
+
+This allows one workload definition to be expanded into multiple empirical experiments without duplicating configuration.
+
+```text
+Prompt Strategy Specification
+            │
+            ▼
+     Model Requirements
+            │
+            ▼
+       Model Discovery
+            │
+            ▼
+ Executable Model Registry
+            │
+            ▼
+   Candidate Generation
+            │
+            ▼
+ Executable Strategies
+```
+
+Candidate generation intentionally separates workload definition from runtime execution.
+
+The specification describes *what* should be evaluated.
+
+The generated candidates describe *how* that workload will be executed using specific language models.
+
+This separation allows optimization to compare multiple executable strategies while preserving a single immutable workload definition.
+
+---
+
 ## Model Requirements
 
 Before a strategy can be executed, it declares the capabilities it requires from a language model.

--- a/docs/adrs/0012-separate-strategy-specifications-from-executable-candidates.md
+++ b/docs/adrs/0012-separate-strategy-specifications-from-executable-candidates.md
@@ -1,0 +1,67 @@
+# ADR 0012: Separate Strategy Specifications from Executable Candidates
+
+## Status
+
+Accepted
+
+## Context
+
+Prompt strategies originally represented executable workloads because they contained a concrete language model implementation.
+
+As Azathoth evolved toward empirical optimization, a single workload needed to be evaluated across multiple language models without duplicating workload definitions.
+
+The architecture therefore required a distinction between:
+
+- describing a workload; and
+- executing that workload with a specific language model.
+
+Additionally, generated candidates require stable identities so experimental evidence can be attributed to the correct executable strategy.
+
+## Decision
+
+Introduce immutable `PromptStrategySpec` objects that describe a prompt-backed workload independently of any executable language model.
+
+Candidate generation combines:
+
+- a prompt strategy specification;
+- model requirements;
+- a model catalog; and
+- an executable language model registry
+
+to produce executable `PromptStrategy` instances.
+
+Each generated candidate:
+
+- is bound to exactly one executable language model;
+- receives a deterministic identity derived from the specification identifier and model identifier;
+- preserves the workload definition while representing an independently executable strategy.
+
+## Consequences
+
+Positive:
+
+- workload definitions become reusable and serializable;
+- executable strategies become runtime artifacts;
+- one specification can generate multiple empirical candidates;
+- candidate identities remain stable across repeated generation;
+- experimental evidence can be attributed to specific model-bound strategies;
+- future model arbitrage and automatic strategy generation build naturally on this architecture.
+
+Negative:
+
+- candidate generation introduces an additional translation step between specification and execution;
+- executable strategies no longer share the same identity as their originating specification.
+
+## Alternatives Considered
+
+### Bind language models directly to specifications
+
+Rejected because specifications would become runtime objects rather than durable workload definitions.
+
+### Reuse specification identities for generated candidates
+
+Rejected because multiple executable strategies would share the same identity, preventing reliable attribution of experimental evidence.
+
+## Result
+
+Azathoth now cleanly separates workload definition from executable strategy generation, allowing a single specification to produce multiple deterministic, model-bound candidates suitable for empirical optimization.

--- a/src/azathoth/prompting/__init__.py
+++ b/src/azathoth/prompting/__init__.py
@@ -8,12 +8,17 @@ from azathoth.prompting.exceptions import (
     PromptBindingFieldNotFoundError,
     PromptingError,
 )
-from azathoth.prompting.models import PromptBinding, PromptTemplate
+from azathoth.prompting.models import (
+    ModelBinding,
+    PromptBinding,
+    PromptTemplate,
+)
 from azathoth.prompting.specifications import PromptStrategySpec
 from azathoth.prompting.strategy import PromptStrategy
 
 __all__ = [
     "ContextPromptStrategy",
+    "ModelBinding",
     "PromptBinding",
     "PromptBindingError",
     "PromptBindingEventNotFoundError",

--- a/src/azathoth/prompting/candidates.py
+++ b/src/azathoth/prompting/candidates.py
@@ -1,7 +1,8 @@
-"""Generate executable prompt strategy candidates from specifications."""
+"""Generate executable prompt strategy candidates."""
 
 from uuid import uuid5
 
+from azathoth.prompting.models import ModelBinding
 from azathoth.prompting.specifications import PromptStrategySpec
 from azathoth.prompting.strategy import PromptStrategy
 from azathoth.providers import (
@@ -17,12 +18,13 @@ def generate_prompt_candidates(
     catalog: ModelCatalog,
     registry: LanguageModelRegistry,
 ) -> tuple[PromptStrategy, ...]:
-    """Generate one executable strategy for each eligible available model."""
+    """Generate executable candidates for eligible registered models."""
 
-    query = ModelQuery.from_requirements(
-        specification.model_requirements
+    eligible_models = catalog.find(
+        ModelQuery.from_requirements(
+            specification.model_requirements
+        )
     )
-    eligible_models = catalog.find(query)
 
     candidates: list[PromptStrategy] = []
 
@@ -41,10 +43,7 @@ def generate_prompt_candidates(
                 f"{specification.metadata.name} "
                 f"[{model_metadata.identifier}]"
             ),
-            description=(
-                f"{specification.metadata.description} "
-                f"Executed using {model_metadata.identifier}."
-            ),
+            description=specification.metadata.description,
             version=specification.metadata.version,
         )
 
@@ -54,6 +53,9 @@ def generate_prompt_candidates(
                 prompt=specification.prompt,
                 language_model=language_model,
                 model_requirements=specification.model_requirements,
+                model_binding=ModelBinding(
+                    identifier=model_metadata.identifier,
+                ),
             )
         )
 

--- a/src/azathoth/prompting/context_strategy.py
+++ b/src/azathoth/prompting/context_strategy.py
@@ -1,7 +1,7 @@
 """Context-aware language-model-backed strategies."""
 
 from azathoth.context import Context
-from azathoth.prompting.models import PromptTemplate
+from azathoth.prompting.models import ModelBinding, PromptTemplate
 from azathoth.providers import LanguageModel, ModelRequirements
 from azathoth.strategies import (
     StrategyExecutionMetrics,
@@ -20,11 +20,13 @@ class ContextPromptStrategy:
         template: PromptTemplate,
         language_model: LanguageModel,
         model_requirements: ModelRequirements | None = None,
+        model_binding: ModelBinding | None = None,
     ) -> None:
         self._metadata = metadata
         self._template = template
         self._language_model = language_model
         self._model_requirements = model_requirements
+        self._model_binding = model_binding
 
     @property
     def metadata(self) -> StrategyMetadata:
@@ -43,6 +45,12 @@ class ContextPromptStrategy:
         """Return the requirements declared for the backing model."""
 
         return self._model_requirements
+    
+    @property
+    def model_binding(self) -> ModelBinding | None:
+        """Return the catalog model bound to this strategy."""
+
+        return self._model_binding
 
     async def run(self, context: Context) -> StrategyOutcome:
         """Render and execute the prompt against the supplied context."""

--- a/src/azathoth/prompting/models.py
+++ b/src/azathoth/prompting/models.py
@@ -10,6 +10,14 @@ from azathoth.prompting.exceptions import (
 from azathoth.providers import Prompt
 
 
+class ModelBinding(BaseModel):
+    """Identify the catalog model bound to an executable prompt strategy."""
+
+    model_config = ConfigDict(frozen=True)
+
+    identifier: str = Field(min_length=1)
+
+
 class PromptBinding(BaseModel):
     """Bind one prompt variable to a field in the latest matching event."""
 
@@ -57,3 +65,5 @@ class PromptTemplate(BaseModel):
         return Prompt(
             text=self.text.format_map(values),
         )
+
+

--- a/src/azathoth/prompting/strategy.py
+++ b/src/azathoth/prompting/strategy.py
@@ -1,6 +1,7 @@
 """Language-model-backed prompt strategies."""
 
 from azathoth.context import Context
+from azathoth.prompting.models import ModelBinding
 from azathoth.providers import (
     LanguageModel,
     ModelRequirements,
@@ -23,11 +24,13 @@ class PromptStrategy:
         prompt: Prompt,
         language_model: LanguageModel,
         model_requirements: ModelRequirements | None = None,
+        model_binding: ModelBinding | None = None,
     ) -> None:
         self._metadata = metadata
         self._prompt = prompt
         self._language_model = language_model
         self._model_requirements = model_requirements
+        self._model_binding = model_binding
 
     @property
     def metadata(self) -> StrategyMetadata:
@@ -46,6 +49,12 @@ class PromptStrategy:
         """Return the requirements declared for the backing model."""
 
         return self._model_requirements
+    
+    @property
+    def model_binding(self) -> ModelBinding | None:
+        """Return the catalog model bound to this strategy."""
+
+        return self._model_binding
 
     async def run(self, context: Context) -> StrategyOutcome:
         """Execute the prompt and return the model response text."""

--- a/tests/prompting/test_candidates.py
+++ b/tests/prompting/test_candidates.py
@@ -289,3 +289,93 @@ def test_generation_returns_empty_tuple_for_empty_registry() -> None:
     )
 
     assert candidates == ()
+
+
+def test_generated_candidates_have_model_bindings() -> None:
+    candidates = generate_prompt_candidates(
+        specification=create_specification(),
+        catalog=create_catalog(),
+        registry=create_registry(),
+    )
+
+    assert len(candidates) == 2
+
+    bindings = tuple(candidate.model_binding for candidate in candidates)
+
+    assert all(binding is not None for binding in bindings)
+    assert tuple(binding.identifier for binding in bindings if binding is not None) == (
+        "provider-a/small",
+        "provider-b/large",
+    )
+
+
+def test_candidate_identity_is_derived_from_specification_and_model() -> None:
+    specification = create_specification()
+
+    candidates = generate_prompt_candidates(
+        specification=specification,
+        catalog=create_catalog(),
+        registry=create_registry(),
+    )
+
+    for candidate in candidates:
+        binding = candidate.model_binding
+
+        assert binding is not None
+        assert candidate.metadata.id == uuid5(
+            specification.metadata.id,
+            binding.identifier,
+        )
+
+
+def test_different_model_bindings_get_distinct_candidate_ids() -> None:
+    candidates = generate_prompt_candidates(
+        specification=create_specification(),
+        catalog=create_catalog(),
+        registry=create_registry(),
+    )
+
+    assert len(candidates) == 2
+    assert candidates[0].metadata.id != candidates[1].metadata.id
+
+
+def test_different_specifications_get_distinct_candidate_ids() -> None:
+    first_specification = create_specification()
+    second_specification = first_specification.model_copy(
+        update={
+            "metadata": StrategyMetadata(
+                id=UUID("946d33fd-f74c-45af-b899-405b386d409f"),
+                name=first_specification.metadata.name,
+                description=first_specification.metadata.description,
+                version=first_specification.metadata.version,
+            )
+        }
+    )
+
+    first_candidate = generate_prompt_candidates(
+        specification=first_specification,
+        catalog=create_catalog(),
+        registry=create_registry(),
+    )[0]
+    second_candidate = generate_prompt_candidates(
+        specification=second_specification,
+        catalog=create_catalog(),
+        registry=create_registry(),
+    )[0]
+
+    assert first_candidate.metadata.id != second_candidate.metadata.id
+
+
+def test_generated_candidate_preserves_specification_configuration() -> None:
+    specification = create_specification()
+
+    candidate = generate_prompt_candidates(
+        specification=specification,
+        catalog=create_catalog(),
+        registry=create_registry(),
+    )[0]
+
+    assert candidate.prompt == specification.prompt
+    assert candidate.model_requirements == specification.model_requirements
+    assert candidate.metadata.description == specification.metadata.description
+    assert candidate.metadata.version == specification.metadata.version

--- a/tests/prompting/test_context_strategy.py
+++ b/tests/prompting/test_context_strategy.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from azathoth.context import Context, ContextEvent
 from azathoth.prompting import (
     ContextPromptStrategy,
+    ModelBinding,
     PromptBinding,
     PromptTemplate,
 )
@@ -185,3 +186,43 @@ def test_context_strategy_allows_omitted_model_requirements() -> None:
     )
 
     assert strategy.model_requirements is None
+
+
+def test_context_strategy_exposes_model_binding() -> None:
+    binding = ModelBinding(
+        identifier="provider-a/model-small",
+    )
+
+    strategy = ContextPromptStrategy(
+        metadata=StrategyMetadata(
+            name="Context-aware classification",
+            description="Classify a support request from context.",
+            version="1.0.0",
+        ),
+        template=PromptTemplate(
+            text="Classify: {message}",
+            bindings=(
+                PromptBinding(
+                    variable_name="message",
+                    event_type="customer.message.received",
+                    field_name="message",
+                ),
+            ),
+        ),
+        language_model=RecordingLanguageModel(
+            response_text="duplicate_charge",
+        ),
+        model_binding=binding,
+    )
+
+    assert strategy.model_binding == binding
+
+
+def test_context_strategy_allows_omitted_model_binding() -> None:
+    strategy = create_strategy(
+        RecordingLanguageModel(
+            response_text="duplicate_charge",
+        )
+    )
+
+    assert strategy.model_binding is None

--- a/tests/prompting/test_model_binding.py
+++ b/tests/prompting/test_model_binding.py
@@ -1,0 +1,126 @@
+"""Tests for prompt strategy model bindings."""
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from azathoth.context import Context
+from azathoth.prompting import ModelBinding, PromptStrategy
+from azathoth.providers import ModelResponse, Prompt
+from azathoth.strategies import StrategyMetadata
+
+
+class RecordingLanguageModel:
+    """A deterministic language model for binding tests."""
+
+    def __init__(self) -> None:
+        self.received_prompt: Prompt | None = None
+
+    async def complete(self, prompt: Prompt) -> ModelResponse:
+        """Record the prompt and return a deterministic response."""
+
+        self.received_prompt = prompt
+
+        return ModelResponse(
+            text="duplicate_charge",
+            provider="provider-a",
+            model="model-small",
+            prompt_tokens=10,
+            completion_tokens=2,
+            total_tokens=12,
+            latency_ms=15,
+            estimated_cost_usd=0.0001,
+        )
+
+
+def create_strategy(
+    *,
+    language_model: RecordingLanguageModel,
+    model_binding: ModelBinding | None = None,
+) -> PromptStrategy:
+    """Create a deterministic prompt strategy."""
+
+    return PromptStrategy(
+        metadata=StrategyMetadata(
+            name="Classify support request",
+            description="Classify a support request using a language model.",
+            version="1.0.0",
+        ),
+        prompt=Prompt(
+            text="Classify the support request.",
+        ),
+        language_model=language_model,
+        model_binding=model_binding,
+    )
+
+
+def test_model_binding_records_provider_qualified_identifier() -> None:
+    binding = ModelBinding(
+        identifier="provider-a/model-small",
+    )
+
+    assert binding.identifier == "provider-a/model-small"
+
+
+def test_model_binding_rejects_empty_identifier() -> None:
+    with pytest.raises(ValidationError):
+        ModelBinding(identifier="")
+
+
+def test_model_binding_is_immutable() -> None:
+    binding = ModelBinding(
+        identifier="provider-a/model-small",
+    )
+
+    with pytest.raises(ValidationError):
+        binding.identifier = "provider-b/model-large"
+
+
+def test_model_binding_round_trips_through_json() -> None:
+    binding = ModelBinding(
+        identifier="provider-a/model-small",
+    )
+
+    restored = ModelBinding.model_validate_json(binding.model_dump_json())
+
+    assert restored == binding
+
+
+def test_prompt_strategy_exposes_model_binding() -> None:
+    binding = ModelBinding(
+        identifier="provider-a/model-small",
+    )
+
+    strategy = create_strategy(
+        language_model=RecordingLanguageModel(),
+        model_binding=binding,
+    )
+
+    assert strategy.model_binding == binding
+
+
+def test_prompt_strategy_allows_omitted_model_binding() -> None:
+    strategy = create_strategy(
+        language_model=RecordingLanguageModel(),
+    )
+
+    assert strategy.model_binding is None
+
+
+def test_model_binding_does_not_change_execution() -> None:
+    model = RecordingLanguageModel()
+    binding = ModelBinding(
+        identifier="provider-a/model-small",
+    )
+    strategy = create_strategy(
+        language_model=model,
+        model_binding=binding,
+    )
+
+    outcome = asyncio.run(strategy.run(Context()))
+
+    assert model.received_prompt == Prompt(
+        text="Classify the support request.",
+    )
+    assert outcome.output == "duplicate_charge"


### PR DESCRIPTION
# Summary

This PR separates prompt workload definitions from executable prompt strategies.

Prompt strategy specifications now describe workloads independently of any concrete language model. Candidate generation combines workload specifications, model requirements, the model catalog, and the executable model registry to generate executable prompt strategies.

Generated candidates receive deterministic identities derived from both the originating specification and the bound language model, allowing empirical evidence to be attributed to the correct executable strategy.

## Changes

- introduced executable model bindings;
- generated deterministic model-bound strategy identities;
- generated executable prompt strategy candidates from workload specifications;
- documented candidate generation architecture;
- added ADR describing the separation between specifications and executable strategies.

## Why

This establishes the architectural boundary between describing a workload and executing that workload.

The resulting design allows:

- reusable workload specifications;
- provider-independent model discovery;
- deterministic candidate identities;
- reproducible experiments;
- future automatic strategy generation;
- future model arbitrage.

## Testing

- added comprehensive candidate generation tests;
- verified deterministic candidate identity generation;
- verified model bindings;
- verified executable model selection;
- verified catalog ordering;
- verified prompt and requirement preservation;
- full test suite passing;
- mypy, Ruff, and CI green.

Closes the next milestone toward automatic empirical optimization.