### PR TITLE
Represent workflows as dependency graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,27 +142,78 @@ This provides:
 
 # Workflow Specifications
 
-Workflows are durable descriptions of work.
+Azathoth represents workflows as durable dependency graphs.
 
-They contain:
+A workflow describes *what* work should be performed without embedding runtime execution concerns.
 
--   workflow metadata
--   ordered workflow step specifications
+Each workflow consists of:
 
-Workflow specifications intentionally contain **no executable language
-models, tools, or runtime state**.
+- workflow metadata;
+- workflow step specifications; and
+- explicit dependency relationships between workflow steps.
+
+```text
+Workflow
+      │
+      ▼
+ Step A
+  │   │
+  ▼   ▼
+Step B Step C
+   \   /
+    ▼ ▼
+   Step D
+```
 
 Each workflow step owns its own executable specification.
 
-This preserves the ability for different workflow steps to use
-different:
+Today that specification is a prompt strategy specification.
 
--   language models
--   tools
--   context requirements
--   execution policies
+Future workflow step types may include:
 
-without coupling an entire workflow to a single runtime.
+- prompt strategies;
+- retrieval;
+- tool invocation;
+- deterministic computation;
+- conditional routing; and
+- human review.
+
+Importantly, execution requirements remain **step-scoped**.
+
+Different workflow steps may require different:
+
+- language models;
+- context windows;
+- model capabilities;
+- execution policies; and
+- tools.
+
+Workflow specifications intentionally contain no executable language models, runtime schedulers, or execution state.
+
+## Dependency Planning
+
+Workflow specifications expose deterministic execution layers.
+
+Each layer contains workflow steps whose dependencies have already been satisfied.
+
+```text
+Layer 1
+──────────────
+Classify Request
+Detect Question
+
+Layer 2
+──────────────
+Retrieve Documents
+
+Layer 3
+──────────────
+Reason About Answer
+```
+
+Execution layers preserve declared workflow order while exposing opportunities for future parallel execution.
+
+This separation allows workflow definitions to remain durable, serializable, and provider-neutral while providing a stable foundation for future workflow execution and optimization.
 
 ------------------------------------------------------------------------
 

--- a/docs/adrs/0015-workflow-dependency-graphs.md
+++ b/docs/adrs/0015-workflow-dependency-graphs.md
@@ -1,0 +1,66 @@
+# ADR 0015: Represent Workflows as Dependency Graphs
+
+- Status: Accepted
+- Date: 2026-08-06
+
+## Context
+
+Azathoth represents AI systems as workflows composed of independently configured workflow steps.
+
+As workflows become more sophisticated, simple sequential ordering is no longer sufficient.
+
+Many AI systems naturally contain independent work that can execute concurrently, while other steps must wait until prerequisite work has completed.
+
+The workflow model therefore requires an explicit representation of dependency relationships without introducing runtime execution behavior.
+
+## Decision
+
+Workflow step specifications may declare dependencies on other workflow steps.
+
+A workflow therefore represents a directed acyclic graph (DAG) rather than a simple ordered list.
+
+Workflow specifications validate that:
+
+- every dependency references another step in the same workflow;
+- workflow steps cannot depend on themselves;
+- dependency declarations are unique; and
+- dependency graphs are acyclic.
+
+Workflow specifications expose deterministic execution layers derived from the dependency graph.
+
+Each execution layer contains workflow steps whose dependencies have already been satisfied.
+
+Execution layers preserve the declared ordering of independent workflow steps while exposing opportunities for future concurrent execution.
+
+Workflow specifications remain durable configuration and contain no runtime scheduling or execution behavior.
+
+## Consequences
+
+### Positive
+
+- Workflow topology is represented explicitly.
+- Independent workflow steps can be identified deterministically.
+- Future workflow runners can execute dependency layers without redefining workflow structure.
+- Parallel execution opportunities are preserved.
+- Workflow planning remains deterministic and reproducible.
+- Individual workflow steps continue to own their own model requirements and execution configuration.
+
+### Negative
+
+- Workflow planning introduces additional validation complexity during construction.
+
+## Alternatives Considered
+
+### Represent workflows as ordered lists
+
+Rejected because ordering alone cannot represent independent work or synchronization points.
+
+### Perform dependency validation during execution
+
+Rejected because invalid workflow topology should be rejected before execution begins.
+
+### Introduce a workflow scheduler
+
+Rejected because scheduling is a runtime concern.
+
+Workflow specifications intentionally remain execution-independent.

--- a/src/azathoth/workflows/models.py
+++ b/src/azathoth/workflows/models.py
@@ -25,7 +25,6 @@ class WorkflowSpecification(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     metadata: WorkflowMetadata
-
     steps: tuple[WorkflowStepSpecification, ...] = Field(
         min_length=1,
     )
@@ -38,5 +37,49 @@ class WorkflowSpecification(BaseModel):
 
         if len(step_ids) != len(set(step_ids)):
             raise ValueError("Workflow step identifiers must be unique.")
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_dependency_graph(self) -> Self:
+        """Ensure workflow dependencies form a valid directed acyclic graph."""
+
+        steps_by_id = {step.id: step for step in self.steps}
+
+        for step in self.steps:
+            if len(step.depends_on) != len(set(step.depends_on)):
+                raise ValueError("Workflow step dependencies must be unique.")
+
+            if step.id in step.depends_on:
+                raise ValueError("Workflow steps cannot depend on themselves.")
+
+            for dependency_id in step.depends_on:
+                if dependency_id not in steps_by_id:
+                    raise ValueError(
+                        "Workflow step dependencies must reference steps in the same workflow."
+                    )
+
+        visiting: set[UUID] = set()
+        visited: set[UUID] = set()
+
+        def visit(step_id: UUID) -> None:
+            """Visit one workflow step while detecting dependency cycles."""
+
+            if step_id in visited:
+                return
+
+            if step_id in visiting:
+                raise ValueError("Workflow dependency graph must be acyclic.")
+
+            visiting.add(step_id)
+
+            for dependency_id in steps_by_id[step_id].depends_on:
+                visit(dependency_id)
+
+            visiting.remove(step_id)
+            visited.add(step_id)
+
+        for step in self.steps:
+            visit(step.id)
 
         return self

--- a/src/azathoth/workflows/models.py
+++ b/src/azathoth/workflows/models.py
@@ -83,3 +83,30 @@ class WorkflowSpecification(BaseModel):
             visit(step.id)
 
         return self
+
+    def execution_layers(
+        self,
+    ) -> tuple[tuple[WorkflowStepSpecification, ...], ...]:
+        """Return dependency-safe workflow steps grouped into layers."""
+
+        remaining = list(self.steps)
+        completed_ids: set[UUID] = set()
+        layers: list[tuple[WorkflowStepSpecification, ...]] = []
+
+        while remaining:
+            ready = tuple(
+                step for step in remaining if set(step.depends_on).issubset(completed_ids)
+            )
+
+            if not ready:
+                raise RuntimeError(
+                    "Validated workflow dependency graph could not produce an execution layer."
+                )
+
+            layers.append(ready)
+
+            ready_ids = {step.id for step in ready}
+            completed_ids.update(ready_ids)
+            remaining = [step for step in remaining if step.id not in ready_ids]
+
+        return tuple(layers)

--- a/src/azathoth/workflows/steps.py
+++ b/src/azathoth/workflows/steps.py
@@ -8,10 +8,10 @@ from azathoth.prompting import PromptStrategySpec
 
 
 class WorkflowStepSpecification(BaseModel):
-    """Describe one step of a workflow."""
+    """Describe one independently configured step of a workflow."""
 
     model_config = ConfigDict(frozen=True)
 
     id: UUID = Field(default_factory=uuid4)
-
     specification: PromptStrategySpec
+    depends_on: tuple[UUID, ...] = ()

--- a/tests/workflows/test_models.py
+++ b/tests/workflows/test_models.py
@@ -18,27 +18,31 @@ WORKFLOW_ID = UUID("a71a5bfb-e2cc-48d5-a055-985cc6450e48")
 STEP_ONE_ID = UUID("7f8cc955-8cbf-407e-a902-7d8c8465696b")
 STEP_TWO_ID = UUID("aa2ff5c7-ac35-44e2-af83-caf0b88b95c1")
 STEP_THREE_ID = UUID("7f496d81-759b-45a3-91cb-f412abf17613")
+UNKNOWN_STEP_ID = UUID("0f14b3fa-f45c-4c49-9c5a-e43ef1c28493")
 
 
 def create_step(
     *,
     step_id: UUID,
     name: str,
+    depends_on: tuple[UUID, ...] = (),
 ) -> WorkflowStepSpecification:
-    """Create a deterministic prompt-backed workflow step."""
+    """Create a deterministic workflow step specification."""
 
     return WorkflowStepSpecification(
         id=step_id,
         specification=PromptStrategySpec(
             metadata=StrategyMetadata(
                 name=name,
-                description=f"{name} description.",
+                description=f"Execute the {name.lower()} step.",
+                version="1.0.0",
             ),
             prompt=Prompt(
-                text=f"{name} prompt.",
+                text=f"Perform the {name.lower()} step.",
             ),
             model_requirements=ModelRequirements(),
         ),
+        depends_on=depends_on,
     )
 
 
@@ -192,6 +196,322 @@ def test_workflow_specification_accepts_distinct_step_ids() -> None:
     )
 
     assert tuple(step.id for step in workflow.steps) == (
+        STEP_ONE_ID,
+        STEP_TWO_ID,
+    )
+
+
+def test_workflow_rejects_dependency_outside_workflow() -> None:
+    """Reject dependencies that do not identify a workflow step."""
+
+    first_step = create_step(
+        step_id=STEP_ONE_ID,
+        name="First",
+    )
+    second_step = create_step(
+        step_id=STEP_TWO_ID,
+        name="Second",
+        depends_on=(UNKNOWN_STEP_ID,),
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=("Workflow step dependencies must reference steps in the same workflow"),
+    ):
+        WorkflowSpecification(
+            metadata=WorkflowMetadata(
+                name="Invalid dependency workflow",
+                description=("A workflow containing an unknown dependency."),
+            ),
+            steps=(
+                first_step,
+                second_step,
+            ),
+        )
+
+
+def test_workflow_rejects_self_dependency() -> None:
+    """Reject a workflow step that depends on itself."""
+
+    step = create_step(
+        step_id=STEP_ONE_ID,
+        name="Self-dependent",
+        depends_on=(STEP_ONE_ID,),
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="Workflow steps cannot depend on themselves",
+    ):
+        WorkflowSpecification(
+            metadata=WorkflowMetadata(
+                name="Self-dependent workflow",
+                description=("A workflow containing a self-dependent step."),
+            ),
+            steps=(step,),
+        )
+
+
+def test_workflow_rejects_duplicate_step_dependencies() -> None:
+    """Reject repeated dependencies on the same predecessor step."""
+
+    first_step = create_step(
+        step_id=STEP_ONE_ID,
+        name="First",
+    )
+    second_step = create_step(
+        step_id=STEP_TWO_ID,
+        name="Second",
+        depends_on=(
+            STEP_ONE_ID,
+            STEP_ONE_ID,
+        ),
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="Workflow step dependencies must be unique",
+    ):
+        WorkflowSpecification(
+            metadata=WorkflowMetadata(
+                name="Duplicate dependency workflow",
+                description=("A workflow containing a repeated dependency."),
+            ),
+            steps=(
+                first_step,
+                second_step,
+            ),
+        )
+
+
+def test_workflow_rejects_two_step_dependency_cycle() -> None:
+    """Reject a dependency cycle between two workflow steps."""
+
+    first_step = create_step(
+        step_id=STEP_ONE_ID,
+        name="First",
+        depends_on=(STEP_TWO_ID,),
+    )
+    second_step = create_step(
+        step_id=STEP_TWO_ID,
+        name="Second",
+        depends_on=(STEP_ONE_ID,),
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="Workflow dependency graph must be acyclic",
+    ):
+        WorkflowSpecification(
+            metadata=WorkflowMetadata(
+                name="Cyclic workflow",
+                description=("A workflow containing a two-step dependency cycle."),
+            ),
+            steps=(
+                first_step,
+                second_step,
+            ),
+        )
+
+
+def test_workflow_rejects_multi_step_dependency_cycle() -> None:
+    """Reject a dependency cycle spanning several workflow steps."""
+
+    first_step = create_step(
+        step_id=STEP_ONE_ID,
+        name="First",
+        depends_on=(STEP_THREE_ID,),
+    )
+    second_step = create_step(
+        step_id=STEP_TWO_ID,
+        name="Second",
+        depends_on=(STEP_ONE_ID,),
+    )
+    third_step = create_step(
+        step_id=STEP_THREE_ID,
+        name="Third",
+        depends_on=(STEP_TWO_ID,),
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="Workflow dependency graph must be acyclic",
+    ):
+        WorkflowSpecification(
+            metadata=WorkflowMetadata(
+                name="Multi-step cyclic workflow",
+                description=("A workflow containing a three-step dependency cycle."),
+            ),
+            steps=(
+                first_step,
+                second_step,
+                third_step,
+            ),
+        )
+
+
+def test_workflow_accepts_linear_dependency_chain() -> None:
+    """Accept an acyclic linear sequence of workflow dependencies."""
+
+    first_step = create_step(
+        step_id=STEP_ONE_ID,
+        name="First",
+    )
+    second_step = create_step(
+        step_id=STEP_TWO_ID,
+        name="Second",
+        depends_on=(STEP_ONE_ID,),
+    )
+    third_step = create_step(
+        step_id=STEP_THREE_ID,
+        name="Third",
+        depends_on=(STEP_TWO_ID,),
+    )
+
+    workflow = WorkflowSpecification(
+        metadata=WorkflowMetadata(
+            name="Linear workflow",
+            description="A valid linear workflow dependency graph.",
+        ),
+        steps=(
+            first_step,
+            second_step,
+            third_step,
+        ),
+    )
+
+    assert workflow.steps == (
+        first_step,
+        second_step,
+        third_step,
+    )
+
+
+def test_workflow_accepts_diamond_dependency_graph() -> None:
+    """Accept multiple parallel steps that converge downstream."""
+
+    fourth_step_id = UUID("73c23fad-c70b-4f5d-b87d-c469c58163c3")
+
+    root_step = create_step(
+        step_id=STEP_ONE_ID,
+        name="Root",
+    )
+    left_step = create_step(
+        step_id=STEP_TWO_ID,
+        name="Left",
+        depends_on=(STEP_ONE_ID,),
+    )
+    right_step = create_step(
+        step_id=STEP_THREE_ID,
+        name="Right",
+        depends_on=(STEP_ONE_ID,),
+    )
+    final_step = create_step(
+        step_id=fourth_step_id,
+        name="Final",
+        depends_on=(
+            STEP_TWO_ID,
+            STEP_THREE_ID,
+        ),
+    )
+
+    workflow = WorkflowSpecification(
+        metadata=WorkflowMetadata(
+            name="Diamond workflow",
+            description="A valid diamond-shaped dependency graph.",
+        ),
+        steps=(
+            root_step,
+            left_step,
+            right_step,
+            final_step,
+        ),
+    )
+
+    assert workflow.steps[-1].depends_on == (
+        STEP_TWO_ID,
+        STEP_THREE_ID,
+    )
+
+
+def test_workflow_accepts_multiple_root_steps() -> None:
+    """Accept workflows containing several independent root steps."""
+
+    first_root = create_step(
+        step_id=STEP_ONE_ID,
+        name="First root",
+    )
+    second_root = create_step(
+        step_id=STEP_TWO_ID,
+        name="Second root",
+    )
+    dependent_step = create_step(
+        step_id=STEP_THREE_ID,
+        name="Dependent",
+        depends_on=(
+            STEP_ONE_ID,
+            STEP_TWO_ID,
+        ),
+    )
+
+    workflow = WorkflowSpecification(
+        metadata=WorkflowMetadata(
+            name="Multiple root workflow",
+            description=("A workflow whose final step depends on two roots."),
+        ),
+        steps=(
+            first_root,
+            second_root,
+            dependent_step,
+        ),
+    )
+
+    assert workflow.steps[0].depends_on == ()
+    assert workflow.steps[1].depends_on == ()
+    assert workflow.steps[2].depends_on == (
+        STEP_ONE_ID,
+        STEP_TWO_ID,
+    )
+
+
+def test_workflow_dependency_graph_round_trips_through_json() -> None:
+    """Preserve workflow dependencies through serialization."""
+
+    first_step = create_step(
+        step_id=STEP_ONE_ID,
+        name="First",
+    )
+    second_step = create_step(
+        step_id=STEP_TWO_ID,
+        name="Second",
+        depends_on=(STEP_ONE_ID,),
+    )
+    third_step = create_step(
+        step_id=STEP_THREE_ID,
+        name="Third",
+        depends_on=(
+            STEP_ONE_ID,
+            STEP_TWO_ID,
+        ),
+    )
+
+    workflow = WorkflowSpecification(
+        metadata=WorkflowMetadata(
+            name="Serializable dependency workflow",
+            description=("A workflow used to verify graph serialization."),
+        ),
+        steps=(
+            first_step,
+            second_step,
+            third_step,
+        ),
+    )
+
+    restored = WorkflowSpecification.model_validate_json(workflow.model_dump_json())
+
+    assert restored == workflow
+    assert restored.steps[1].depends_on == (STEP_ONE_ID,)
+    assert restored.steps[2].depends_on == (
         STEP_ONE_ID,
         STEP_TWO_ID,
     )

--- a/tests/workflows/test_planning.py
+++ b/tests/workflows/test_planning.py
@@ -1,0 +1,230 @@
+"""Tests for deterministic workflow execution planning."""
+
+from uuid import UUID
+
+from azathoth.prompting import PromptStrategySpec
+from azathoth.providers import ModelRequirements, Prompt
+from azathoth.strategies import StrategyMetadata
+from azathoth.workflows import (
+    WorkflowMetadata,
+    WorkflowSpecification,
+    WorkflowStepSpecification,
+)
+
+STEP_A_ID = UUID("e445a23b-f66c-4498-8224-eed45aa98b23")
+STEP_B_ID = UUID("73ed36d8-d27d-44c7-a04d-3945d549dc43")
+STEP_C_ID = UUID("61e4c807-259e-487a-bf58-b188db795482")
+STEP_D_ID = UUID("1346cc9b-3c1b-408d-a8b6-1c79864c2d27")
+
+
+def create_step(
+    *,
+    step_id: UUID,
+    name: str,
+    depends_on: tuple[UUID, ...] = (),
+) -> WorkflowStepSpecification:
+    """Create a deterministic workflow step."""
+
+    return WorkflowStepSpecification(
+        id=step_id,
+        depends_on=depends_on,
+        specification=PromptStrategySpec(
+            metadata=StrategyMetadata(
+                name=name,
+                description=f"Execute the {name} step.",
+                version="1.0.0",
+            ),
+            prompt=Prompt(
+                text=f"Execute {name}.",
+            ),
+            model_requirements=ModelRequirements(),
+        ),
+    )
+
+
+def create_workflow(
+    *steps: WorkflowStepSpecification,
+) -> WorkflowSpecification:
+    """Create a deterministic workflow containing supplied steps."""
+
+    return WorkflowSpecification(
+        metadata=WorkflowMetadata(
+            name="Execution planning workflow",
+            description="A workflow used to test dependency planning.",
+            version="1.0.0",
+        ),
+        steps=steps,
+    )
+
+
+def test_execution_layers_for_linear_workflow() -> None:
+    step_a = create_step(
+        step_id=STEP_A_ID,
+        name="A",
+    )
+    step_b = create_step(
+        step_id=STEP_B_ID,
+        name="B",
+        depends_on=(STEP_A_ID,),
+    )
+    step_c = create_step(
+        step_id=STEP_C_ID,
+        name="C",
+        depends_on=(STEP_B_ID,),
+    )
+
+    workflow = create_workflow(
+        step_a,
+        step_b,
+        step_c,
+    )
+
+    layers = workflow.execution_layers()
+
+    assert tuple(tuple(step.id for step in layer) for layer in layers) == (
+        (STEP_A_ID,),
+        (STEP_B_ID,),
+        (STEP_C_ID,),
+    )
+
+
+def test_independent_root_steps_share_first_execution_layer() -> None:
+    step_a = create_step(
+        step_id=STEP_A_ID,
+        name="A",
+    )
+    step_b = create_step(
+        step_id=STEP_B_ID,
+        name="B",
+    )
+    step_c = create_step(
+        step_id=STEP_C_ID,
+        name="C",
+        depends_on=(
+            STEP_A_ID,
+            STEP_B_ID,
+        ),
+    )
+
+    workflow = create_workflow(
+        step_a,
+        step_b,
+        step_c,
+    )
+
+    layers = workflow.execution_layers()
+
+    assert tuple(tuple(step.id for step in layer) for layer in layers) == (
+        (
+            STEP_A_ID,
+            STEP_B_ID,
+        ),
+        (STEP_C_ID,),
+    )
+
+
+def test_execution_layers_for_diamond_workflow() -> None:
+    step_a = create_step(
+        step_id=STEP_A_ID,
+        name="A",
+    )
+    step_b = create_step(
+        step_id=STEP_B_ID,
+        name="B",
+        depends_on=(STEP_A_ID,),
+    )
+    step_c = create_step(
+        step_id=STEP_C_ID,
+        name="C",
+        depends_on=(STEP_A_ID,),
+    )
+    step_d = create_step(
+        step_id=STEP_D_ID,
+        name="D",
+        depends_on=(
+            STEP_B_ID,
+            STEP_C_ID,
+        ),
+    )
+
+    workflow = create_workflow(
+        step_a,
+        step_b,
+        step_c,
+        step_d,
+    )
+
+    layers = workflow.execution_layers()
+
+    assert tuple(tuple(step.id for step in layer) for layer in layers) == (
+        (STEP_A_ID,),
+        (
+            STEP_B_ID,
+            STEP_C_ID,
+        ),
+        (STEP_D_ID,),
+    )
+
+
+def test_execution_layers_preserve_declared_order() -> None:
+    step_b = create_step(
+        step_id=STEP_B_ID,
+        name="B",
+    )
+    step_a = create_step(
+        step_id=STEP_A_ID,
+        name="A",
+    )
+    step_c = create_step(
+        step_id=STEP_C_ID,
+        name="C",
+        depends_on=(
+            STEP_A_ID,
+            STEP_B_ID,
+        ),
+    )
+
+    workflow = create_workflow(
+        step_b,
+        step_a,
+        step_c,
+    )
+
+    layers = workflow.execution_layers()
+
+    assert tuple(step.id for step in layers[0]) == (
+        STEP_B_ID,
+        STEP_A_ID,
+    )
+
+
+def test_execution_planning_does_not_mutate_workflow() -> None:
+    step_a = create_step(
+        step_id=STEP_A_ID,
+        name="A",
+    )
+    step_b = create_step(
+        step_id=STEP_B_ID,
+        name="B",
+        depends_on=(STEP_A_ID,),
+    )
+    workflow = create_workflow(
+        step_a,
+        step_b,
+    )
+    original_steps = workflow.steps
+
+    workflow.execution_layers()
+
+    assert workflow.steps == original_steps
+
+
+def test_single_step_workflow_has_one_execution_layer() -> None:
+    step = create_step(
+        step_id=STEP_A_ID,
+        name="A",
+    )
+
+    workflow = create_workflow(step)
+
+    assert workflow.execution_layers() == ((step,),)

--- a/tests/workflows/test_planning_composition.py
+++ b/tests/workflows/test_planning_composition.py
@@ -1,0 +1,219 @@
+"""Tests for preserving step configuration during workflow planning."""
+
+from uuid import UUID
+
+from azathoth.prompting import PromptStrategySpec
+from azathoth.providers import (
+    ModelCapability,
+    ModelRequirements,
+    Prompt,
+)
+from azathoth.strategies import StrategyMetadata
+from azathoth.workflows import (
+    WorkflowMetadata,
+    WorkflowSpecification,
+    WorkflowStepSpecification,
+)
+
+CLASSIFIER_STEP_ID = UUID("39e169cf-00a6-4728-bc97-ce1d95021470")
+QUESTION_STEP_ID = UUID("469d8059-b2cc-4ca8-bc18-b3d377052ff8")
+REASONING_STEP_ID = UUID("b4ae6fa8-09df-41a7-94e6-c3eb94ad66a7")
+
+CLASSIFIER_STRATEGY_ID = UUID("20cf4513-4206-413c-a377-d7c6c73d97c2")
+QUESTION_STRATEGY_ID = UUID("4e23402c-fbb6-4bd3-9acc-75f75a8062b0")
+REASONING_STRATEGY_ID = UUID("efcc83d6-73e6-4d43-b00a-ccf73eac9297")
+
+
+def create_prompt_step(
+    *,
+    step_id: UUID,
+    strategy_id: UUID,
+    name: str,
+    requirements: ModelRequirements,
+    depends_on: tuple[UUID, ...] = (),
+) -> WorkflowStepSpecification:
+    """Create a deterministic independently configured prompt step."""
+
+    return WorkflowStepSpecification(
+        id=step_id,
+        depends_on=depends_on,
+        specification=PromptStrategySpec(
+            metadata=StrategyMetadata(
+                id=strategy_id,
+                name=name,
+                description=f"Execute the {name} workflow step.",
+                version="1.0.0",
+            ),
+            prompt=Prompt(
+                text=f"Execute {name}.",
+            ),
+            model_requirements=requirements,
+        ),
+    )
+
+
+def create_workflow() -> WorkflowSpecification:
+    """Create a workflow with independently configured model-backed steps."""
+
+    classifier = create_prompt_step(
+        step_id=CLASSIFIER_STEP_ID,
+        strategy_id=CLASSIFIER_STRATEGY_ID,
+        name="Math classifier",
+        requirements=ModelRequirements(
+            required_capabilities=frozenset(
+                {
+                    ModelCapability.STRUCTURED_OUTPUT,
+                }
+            ),
+            minimum_context_window_tokens=8_000,
+        ),
+    )
+
+    question_detector = create_prompt_step(
+        step_id=QUESTION_STEP_ID,
+        strategy_id=QUESTION_STRATEGY_ID,
+        name="Question detector",
+        requirements=ModelRequirements(
+            required_capabilities=frozenset(
+                {
+                    ModelCapability.STRUCTURED_OUTPUT,
+                }
+            ),
+            minimum_context_window_tokens=16_000,
+        ),
+    )
+
+    reasoning = create_prompt_step(
+        step_id=REASONING_STEP_ID,
+        strategy_id=REASONING_STRATEGY_ID,
+        name="Tool-capable reasoner",
+        requirements=ModelRequirements(
+            required_capabilities=frozenset(
+                {
+                    ModelCapability.TOOL_USE,
+                }
+            ),
+            minimum_context_window_tokens=128_000,
+        ),
+        depends_on=(
+            CLASSIFIER_STEP_ID,
+            QUESTION_STEP_ID,
+        ),
+    )
+
+    return WorkflowSpecification(
+        metadata=WorkflowMetadata(
+            name="Classify and resolve request",
+            description=("Classify the request before running a tool-capable reasoning step."),
+            version="1.0.0",
+        ),
+        steps=(
+            classifier,
+            question_detector,
+            reasoning,
+        ),
+    )
+
+
+def test_execution_layers_preserve_original_step_specifications() -> None:
+    workflow = create_workflow()
+
+    layers = workflow.execution_layers()
+
+    assert layers[0][0] is workflow.steps[0]
+    assert layers[0][1] is workflow.steps[1]
+    assert layers[1][0] is workflow.steps[2]
+
+
+def test_execution_layers_preserve_step_scoped_model_requirements() -> None:
+    workflow = create_workflow()
+
+    layers = workflow.execution_layers()
+
+    classifier_requirements = layers[0][0].specification.model_requirements
+    question_requirements = layers[0][1].specification.model_requirements
+    reasoning_requirements = layers[1][0].specification.model_requirements
+
+    assert classifier_requirements == ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+            }
+        ),
+        minimum_context_window_tokens=8_000,
+    )
+
+    assert question_requirements == ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+            }
+        ),
+        minimum_context_window_tokens=16_000,
+    )
+
+    assert reasoning_requirements == ModelRequirements(
+        required_capabilities=frozenset(
+            {
+                ModelCapability.TOOL_USE,
+            }
+        ),
+        minimum_context_window_tokens=128_000,
+    )
+
+
+def test_workflow_planning_does_not_create_global_model_requirements() -> None:
+    workflow = create_workflow()
+
+    workflow.execution_layers()
+
+    assert "model_requirements" not in WorkflowSpecification.model_fields
+
+
+def test_steps_in_same_layer_keep_independent_requirements() -> None:
+    workflow = create_workflow()
+
+    first_layer = workflow.execution_layers()[0]
+
+    first_requirements = first_layer[0].specification.model_requirements
+    second_requirements = first_layer[1].specification.model_requirements
+
+    assert first_requirements != second_requirements
+    assert first_requirements.minimum_context_window_tokens == 8_000
+    assert second_requirements.minimum_context_window_tokens == 16_000
+
+
+def test_planned_downstream_step_preserves_dependencies_and_requirements() -> None:
+    workflow = create_workflow()
+
+    reasoning_step = workflow.execution_layers()[1][0]
+
+    assert reasoning_step.depends_on == (
+        CLASSIFIER_STEP_ID,
+        QUESTION_STEP_ID,
+    )
+    assert (
+        ModelCapability.TOOL_USE
+        in reasoning_step.specification.model_requirements.required_capabilities
+    )
+    assert reasoning_step.specification.model_requirements.minimum_context_window_tokens == 128_000
+
+
+def test_restored_workflow_produces_equivalent_execution_layers() -> None:
+    workflow = create_workflow()
+
+    restored = WorkflowSpecification.model_validate_json(workflow.model_dump_json())
+
+    original_layers = tuple(
+        tuple(step.id for step in layer) for layer in workflow.execution_layers()
+    )
+    restored_layers = tuple(
+        tuple(step.id for step in layer) for layer in restored.execution_layers()
+    )
+
+    assert restored_layers == original_layers
+
+    assert (
+        restored.execution_layers()[1][0].specification.model_requirements
+        == workflow.execution_layers()[1][0].specification.model_requirements
+    )

--- a/tests/workflows/test_steps.py
+++ b/tests/workflows/test_steps.py
@@ -15,6 +15,8 @@ from azathoth.strategies import StrategyMetadata
 from azathoth.workflows import WorkflowStepSpecification
 
 STEP_ID = UUID("7f8cc955-8cbf-407e-a902-7d8c8465696b")
+DEPENDENCY_ONE_ID = UUID("aa2ff5c7-ac35-44e2-af83-caf0b88b95c1")
+DEPENDENCY_TWO_ID = UUID("7f496d81-759b-45a3-91cb-f412abf17613")
 
 
 def create_prompt_specification() -> PromptStrategySpec:
@@ -107,3 +109,74 @@ def test_workflow_step_round_trips_through_json() -> None:
     restored = WorkflowStepSpecification.model_validate_json(step.model_dump_json())
 
     assert restored == step
+
+
+def test_workflow_step_defaults_to_no_dependencies() -> None:
+    step = WorkflowStepSpecification(
+        id=STEP_ID,
+        specification=create_prompt_specification(),
+    )
+
+    assert step.depends_on == ()
+
+
+def test_workflow_step_records_dependencies() -> None:
+    step = WorkflowStepSpecification(
+        id=STEP_ID,
+        specification=create_prompt_specification(),
+        depends_on=(
+            DEPENDENCY_ONE_ID,
+            DEPENDENCY_TWO_ID,
+        ),
+    )
+
+    assert step.depends_on == (
+        DEPENDENCY_ONE_ID,
+        DEPENDENCY_TWO_ID,
+    )
+
+
+def test_workflow_step_preserves_dependency_order() -> None:
+    step = WorkflowStepSpecification(
+        id=STEP_ID,
+        specification=create_prompt_specification(),
+        depends_on=(
+            DEPENDENCY_TWO_ID,
+            DEPENDENCY_ONE_ID,
+        ),
+    )
+
+    assert step.depends_on == (
+        DEPENDENCY_TWO_ID,
+        DEPENDENCY_ONE_ID,
+    )
+
+
+def test_workflow_step_dependencies_round_trip_through_json() -> None:
+    step = WorkflowStepSpecification(
+        id=STEP_ID,
+        specification=create_prompt_specification(),
+        depends_on=(
+            DEPENDENCY_ONE_ID,
+            DEPENDENCY_TWO_ID,
+        ),
+    )
+
+    restored = WorkflowStepSpecification.model_validate_json(step.model_dump_json())
+
+    assert restored == step
+    assert restored.depends_on == (
+        DEPENDENCY_ONE_ID,
+        DEPENDENCY_TWO_ID,
+    )
+
+
+def test_workflow_step_dependencies_are_immutable() -> None:
+    step = WorkflowStepSpecification(
+        id=STEP_ID,
+        specification=create_prompt_specification(),
+        depends_on=(DEPENDENCY_ONE_ID,),
+    )
+
+    with pytest.raises(ValidationError):
+        step.depends_on = (DEPENDENCY_TWO_ID,)


### PR DESCRIPTION
# Summary

This PR extends workflow specifications from ordered collections of steps into validated dependency graphs.

Workflow steps may now declare dependencies on other workflow steps, allowing workflows to represent synchronization points and independent branches without introducing runtime execution behavior.

Workflow specifications also expose deterministic execution layers derived from the dependency graph.

## Changes

- Added workflow step dependency declarations.
- Validated workflow dependency graphs.
- Rejected invalid dependency relationships.
- Added deterministic execution layer planning.
- Expanded workflow planning test coverage.
- Verified that planning preserves independent step configuration.
- Verified that model requirements remain step-scoped throughout planning.

## Why

Many AI workflows are not strictly sequential.

Independent work should be represented explicitly so that future workflow runners can execute available work without redefining workflow structure.

Representing workflows as dependency graphs preserves provider neutrality while enabling future scheduling, orchestration, and parallel execution.

Keeping model requirements at the workflow-step level also preserves the ability for different workflow steps to use different language models, tools, and execution policies.

## Result

Azathoth now represents workflows as validated dependency graphs.

Workflow specifications are:

- immutable;
- serializable;
- deterministic;
- provider-neutral;
- execution-independent;
- capable of expressing independent workflow branches; and
- ready to support future workflow orchestration.